### PR TITLE
Adding links to feiglab data under new schema.

### DIFF
--- a/data/models/M_protein_feig.yml
+++ b/data/models/M_protein_feig.yml
@@ -1,0 +1,11 @@
+name: Refinement of M_protein by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Contact-based structure prediction using trRosetta. 10 models generated and the best scoring was refined through molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/M_protein.pdb
+pdbids:
+  -
+proteins:
+  - Membrane Glycoprotein
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/M_protein_feig.yml
+++ b/data/models/M_protein_feig.yml
@@ -4,8 +4,7 @@ description: Contact-based structure prediction using trRosetta. 10 models gener
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/M_protein.pdb
 pdbids:
-  -
 proteins:
-  - Membrane Glycoprotein
+  - M protein
 creator: Feig Computational Biophysics Lab
 institution: Michigan State University

--- a/data/models/M_protein_feig_AlphaFold.yml
+++ b/data/models/M_protein_feig_AlphaFold.yml
@@ -4,8 +4,7 @@ description: Physics-based refinement of Google DeepMind AlphaFold models from e
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/M_protein.pdb
 pdbids:
-  -
 proteins:
-  - Membrane Glycoprotein
+  - M protein
 creator: Feig Computational Biophysics Lab
 institution: Michigan State University

--- a/data/models/M_protein_feig_AlphaFold.yml
+++ b/data/models/M_protein_feig_AlphaFold.yml
@@ -1,0 +1,11 @@
+name: Refinement of AplhaFold M_protein by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Physics-based refinement of Google DeepMind AlphaFold models from early March 2020. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/M_protein.pdb
+pdbids:
+  -
+proteins:
+  - Membrane Glycoprotein
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/M_protein_feig_RaptorX.yml
+++ b/data/models/M_protein_feig_RaptorX.yml
@@ -4,8 +4,7 @@ description: FeigLab refinement of RaptorX-Contact models. Refinement performed 
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/M_protein.pdb
 pdbids:
-  -
 proteins:
-  - Membrane Glycoprotein
+  - M protein
 creator: Feig Computational Biophysics Lab
 institution: Michigan State University

--- a/data/models/M_protein_feig_RaptorX.yml
+++ b/data/models/M_protein_feig_RaptorX.yml
@@ -1,0 +1,11 @@
+name: Refinement of RaptorX M_protein by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: FeigLab refinement of RaptorX-Contact models. Refinement performed using a protocol based on molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/M_protein.pdb
+pdbids:
+  -
+proteins:
+  - Membrane Glycoprotein
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/ORF10_feig.yml
+++ b/data/models/ORF10_feig.yml
@@ -1,0 +1,11 @@
+name: Refinement of ORF10 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Contact-based structure prediction using trRosetta. 10 models generated and the best scoring was refined through molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/ORF10.pdb
+pdbids:
+  -
+proteins:
+  - ORF10
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/ORF10_feig.yml
+++ b/data/models/ORF10_feig.yml
@@ -4,7 +4,6 @@ description: Contact-based structure prediction using trRosetta. 10 models gener
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/ORF10.pdb
 pdbids:
-  -
 proteins:
   - ORF10
 creator: Feig Computational Biophysics Lab

--- a/data/models/ORF10_feig_RaptorX.yml
+++ b/data/models/ORF10_feig_RaptorX.yml
@@ -1,0 +1,11 @@
+name: Refinement of RaptorX ORF10 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: FeigLab refinement of RaptorX-Contact models. Refinement performed using a protocol based on molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/ORF10.pdb
+pdbids:
+  -
+proteins:
+  - ORF10
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/ORF10_feig_RaptorX.yml
+++ b/data/models/ORF10_feig_RaptorX.yml
@@ -4,7 +4,6 @@ description: FeigLab refinement of RaptorX-Contact models. Refinement performed 
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/ORF10.pdb
 pdbids:
-  -
 proteins:
   - ORF10
 creator: Feig Computational Biophysics Lab

--- a/data/models/ORF3a_feig.yml
+++ b/data/models/ORF3a_feig.yml
@@ -1,0 +1,11 @@
+name: Refinement of ORF3a by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Contact-based structure prediction using trRosetta. 10 models generated and the best scoring was refined through molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/ORF3a.pdb
+pdbids:
+  -
+proteins:
+  - ORF3a
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/ORF3a_feig.yml
+++ b/data/models/ORF3a_feig.yml
@@ -4,7 +4,6 @@ description: Contact-based structure prediction using trRosetta. 10 models gener
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/ORF3a.pdb
 pdbids:
-  -
 proteins:
   - ORF3a
 creator: Feig Computational Biophysics Lab

--- a/data/models/ORF3a_feig_AlphaFold.yml
+++ b/data/models/ORF3a_feig_AlphaFold.yml
@@ -1,10 +1,10 @@
-name: Refinement of AplhaFold Protein_3a by FeigLab
+name: Refinement of AplhaFold ORF3a by FeigLab
 url: https://github.com/feiglab/sars-cov-2-proteins
 description: Physics-based refinement of Google DeepMind AlphaFold models from early March 2020. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/Protein_3a.pdb
 pdbids:
 proteins:
-  - Protein 3a
+  - ORF3a
 creator: Feig Computational Biophysics Lab
 institution: Michigan State University

--- a/data/models/ORF3a_feig_RaptorX.yml
+++ b/data/models/ORF3a_feig_RaptorX.yml
@@ -1,0 +1,11 @@
+name: Refinement of RaptorX ORF3a by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: FeigLab refinement of RaptorX-Contact models. Refinement performed using a protocol based on molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/ORF3a.pdb
+pdbids:
+  -
+proteins:
+  - ORF3a
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/ORF3a_feig_RaptorX.yml
+++ b/data/models/ORF3a_feig_RaptorX.yml
@@ -4,7 +4,6 @@ description: FeigLab refinement of RaptorX-Contact models. Refinement performed 
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/ORF3a.pdb
 pdbids:
-  -
 proteins:
   - ORF3a
 creator: Feig Computational Biophysics Lab

--- a/data/models/ORF6_feig.yml
+++ b/data/models/ORF6_feig.yml
@@ -1,0 +1,11 @@
+name: Refinement of ORF6 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Contact-based structure prediction using trRosetta. 10 models generated and the best scoring was refined through molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/ORF6.pdb
+pdbids:
+  -
+proteins:
+  - ORF6
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/ORF6_feig.yml
+++ b/data/models/ORF6_feig.yml
@@ -4,7 +4,6 @@ description: Contact-based structure prediction using trRosetta. 10 models gener
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/ORF6.pdb
 pdbids:
-  -
 proteins:
   - ORF6
 creator: Feig Computational Biophysics Lab

--- a/data/models/ORF6_feig_RaptorX.yml
+++ b/data/models/ORF6_feig_RaptorX.yml
@@ -1,0 +1,11 @@
+name: Refinement of RaptorX ORF6 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: FeigLab refinement of RaptorX-Contact models. Refinement performed using a protocol based on molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/ORF6.pdb
+pdbids:
+  -
+proteins:
+  - ORF6
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/ORF6_feig_RaptorX.yml
+++ b/data/models/ORF6_feig_RaptorX.yml
@@ -4,7 +4,6 @@ description: FeigLab refinement of RaptorX-Contact models. Refinement performed 
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/ORF6.pdb
 pdbids:
-  -
 proteins:
   - ORF6
 creator: Feig Computational Biophysics Lab

--- a/data/models/ORF7b_feig.yml
+++ b/data/models/ORF7b_feig.yml
@@ -1,0 +1,11 @@
+name: Refinement of ORF7b by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Contact-based structure prediction using trRosetta. 10 models generated and the best scoring was refined through molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/ORF7b.pdb
+pdbids:
+  -
+proteins:
+  - ORF7b
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/ORF7b_feig.yml
+++ b/data/models/ORF7b_feig.yml
@@ -4,7 +4,6 @@ description: Contact-based structure prediction using trRosetta. 10 models gener
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/ORF7b.pdb
 pdbids:
-  -
 proteins:
   - ORF7b
 creator: Feig Computational Biophysics Lab

--- a/data/models/ORF7b_feig_RaptorX.yml
+++ b/data/models/ORF7b_feig_RaptorX.yml
@@ -1,0 +1,11 @@
+name: Refinement of RaptorX ORF7b by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: FeigLab refinement of RaptorX-Contact models. Refinement performed using a protocol based on molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/ORF7b.pdb
+pdbids:
+  -
+proteins:
+  - ORF7b
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/ORF7b_feig_RaptorX.yml
+++ b/data/models/ORF7b_feig_RaptorX.yml
@@ -4,7 +4,6 @@ description: FeigLab refinement of RaptorX-Contact models. Refinement performed 
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/ORF7b.pdb
 pdbids:
-  -
 proteins:
   - ORF7b
 creator: Feig Computational Biophysics Lab

--- a/data/models/ORF8_feig.yml
+++ b/data/models/ORF8_feig.yml
@@ -1,0 +1,11 @@
+name: Refinement of ORF8 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Contact-based structure prediction using trRosetta. 10 models generated and the best scoring was refined through molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/ORF8.pdb
+pdbids:
+  -
+proteins:
+  - ORF8
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/ORF8_feig.yml
+++ b/data/models/ORF8_feig.yml
@@ -4,7 +4,6 @@ description: Contact-based structure prediction using trRosetta. 10 models gener
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/ORF8.pdb
 pdbids:
-  -
 proteins:
   - ORF8
 creator: Feig Computational Biophysics Lab

--- a/data/models/ORF8_feig_RaptorX.yml
+++ b/data/models/ORF8_feig_RaptorX.yml
@@ -4,7 +4,6 @@ description: FeigLab refinement of RaptorX-Contact models. Refinement performed 
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/ORF8.pdb
 pdbids:
-  -
 proteins:
   - ORF8
 creator: Feig Computational Biophysics Lab

--- a/data/models/ORF8_feig_RaptorX.yml
+++ b/data/models/ORF8_feig_RaptorX.yml
@@ -1,0 +1,11 @@
+name: Refinement of RaptorX ORF8 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: FeigLab refinement of RaptorX-Contact models. Refinement performed using a protocol based on molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/ORF8.pdb
+pdbids:
+  -
+proteins:
+  - ORF8
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/PL-PRO_C_terminal_feig_AlphaFold.yml
+++ b/data/models/PL-PRO_C_terminal_feig_AlphaFold.yml
@@ -4,7 +4,6 @@ description: Physics-based refinement of Google DeepMind AlphaFold models from e
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/PL-PRO_C_terminal.pdb
 pdbids:
-  -
 proteins:
   - PLpro
 creator: Feig Computational Biophysics Lab

--- a/data/models/PL-PRO_C_terminal_feig_AlphaFold.yml
+++ b/data/models/PL-PRO_C_terminal_feig_AlphaFold.yml
@@ -1,0 +1,11 @@
+name: Refinement of AplhaFold PLpro C terminal by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Physics-based refinement of Google DeepMind AlphaFold models from early March 2020. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/PL-PRO_C_terminal.pdb
+pdbids:
+  -
+proteins:
+  - PLpro
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/PL-PRO_feig.yml
+++ b/data/models/PL-PRO_feig.yml
@@ -1,0 +1,11 @@
+name: Refinement of PLpro by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Contact-based structure prediction using trRosetta. 10 models generated and the best scoring was refined through molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/PL-Pro.pdb
+pdbids:
+  -
+proteins:
+  - PLpro
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/PL-PRO_feig.yml
+++ b/data/models/PL-PRO_feig.yml
@@ -4,7 +4,6 @@ description: Contact-based structure prediction using trRosetta. 10 models gener
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/PL-Pro.pdb
 pdbids:
-  -
 proteins:
   - PLpro
 creator: Feig Computational Biophysics Lab

--- a/data/models/PL-PRO_feig_RaptorX.yml
+++ b/data/models/PL-PRO_feig_RaptorX.yml
@@ -1,0 +1,11 @@
+name: Refinement of RaptorX PLpro by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: FeigLab refinement of RaptorX-Contact models. Refinement performed using a protocol based on molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/PL-PRO.pdb
+pdbids:
+  -
+proteins:
+  - PLpro
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/PL-PRO_feig_RaptorX.yml
+++ b/data/models/PL-PRO_feig_RaptorX.yml
@@ -4,7 +4,6 @@ description: FeigLab refinement of RaptorX-Contact models. Refinement performed 
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/PL-PRO.pdb
 pdbids:
-  -
 proteins:
   - PLpro
 creator: Feig Computational Biophysics Lab

--- a/data/models/Protein_3a_feig_AlphaFold.yml
+++ b/data/models/Protein_3a_feig_AlphaFold.yml
@@ -4,8 +4,7 @@ description: Physics-based refinement of Google DeepMind AlphaFold models from e
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/Protein_3a.pdb
 pdbids:
-  -
 proteins:
-  - 3a
+  - Protein 3a
 creator: Feig Computational Biophysics Lab
 institution: Michigan State University

--- a/data/models/Protein_3a_feig_AlphaFold.yml
+++ b/data/models/Protein_3a_feig_AlphaFold.yml
@@ -1,0 +1,11 @@
+name: Refinement of AplhaFold Protein_3a by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Physics-based refinement of Google DeepMind AlphaFold models from early March 2020. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/Protein_3a.pdb
+pdbids:
+  -
+proteins:
+  - 3a
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/nsp2_feig.yml
+++ b/data/models/nsp2_feig.yml
@@ -4,7 +4,6 @@ description: Contact-based structure prediction using trRosetta. 10 models gener
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/nsp2.pdb
 pdbids:
-  -
 proteins:
   - NSP2
 creator: Feig Computational Biophysics Lab

--- a/data/models/nsp2_feig.yml
+++ b/data/models/nsp2_feig.yml
@@ -1,0 +1,11 @@
+name: Refinement of nsp2 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Contact-based structure prediction using trRosetta. 10 models generated and the best scoring was refined through molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/nsp2.pdb
+pdbids:
+  -
+proteins:
+  - NSP2
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/nsp2_feig_AlphaFold.yml
+++ b/data/models/nsp2_feig_AlphaFold.yml
@@ -4,7 +4,6 @@ description: Physics-based refinement of Google DeepMind AlphaFold models from e
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/nsp2.pdb
 pdbids:
-  -
 proteins:
   - NSP2
 creator: Feig Computational Biophysics Lab

--- a/data/models/nsp2_feig_AlphaFold.yml
+++ b/data/models/nsp2_feig_AlphaFold.yml
@@ -1,0 +1,11 @@
+name: Refinement of AplhaFold nsp2 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Physics-based refinement of Google DeepMind AlphaFold models from early March 2020. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/nsp2.pdb
+pdbids:
+  -
+proteins:
+  - NSP2
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/nsp2_feig_RaptorX.yml
+++ b/data/models/nsp2_feig_RaptorX.yml
@@ -4,7 +4,6 @@ description: FeigLab refinement of RaptorX-Contact models. Refinement performed 
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/nsp2.pdb
 pdbids:
-  -
 proteins:
   - NSP2
 creator: Feig Computational Biophysics Lab

--- a/data/models/nsp2_feig_RaptorX.yml
+++ b/data/models/nsp2_feig_RaptorX.yml
@@ -1,0 +1,11 @@
+name: Refinement of RaptorX nsp2 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: FeigLab refinement of RaptorX-Contact models. Refinement performed using a protocol based on molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/nsp2.pdb
+pdbids:
+  -
+proteins:
+  - NSP2
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/nsp4_feig.yml
+++ b/data/models/nsp4_feig.yml
@@ -4,7 +4,6 @@ description: Contact-based structure prediction using trRosetta. 10 models gener
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/nsp4.pdb
 pdbids:
-  -
 proteins:
   - NSP4
 creator: Feig Computational Biophysics Lab

--- a/data/models/nsp4_feig.yml
+++ b/data/models/nsp4_feig.yml
@@ -1,0 +1,11 @@
+name: Refinement of nsp4 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Contact-based structure prediction using trRosetta. 10 models generated and the best scoring was refined through molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/nsp4.pdb
+pdbids:
+  -
+proteins:
+  - NSP4
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/nsp4_feig_AlphaFold.yml
+++ b/data/models/nsp4_feig_AlphaFold.yml
@@ -4,7 +4,6 @@ description: Physics-based refinement of Google DeepMind AlphaFold models from e
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/nsp4.pdb
 pdbids:
-  -
 proteins:
   - NSP4
 creator: Feig Computational Biophysics Lab

--- a/data/models/nsp4_feig_AlphaFold.yml
+++ b/data/models/nsp4_feig_AlphaFold.yml
@@ -1,0 +1,11 @@
+name: Refinement of AplhaFold nsp4 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Physics-based refinement of Google DeepMind AlphaFold models from early March 2020. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/nsp4.pdb
+pdbids:
+  -
+proteins:
+  - NSP4
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/nsp4_feig_RaptorX.yml
+++ b/data/models/nsp4_feig_RaptorX.yml
@@ -1,0 +1,11 @@
+name: Refinement of RaptorX nsp4 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: FeigLab refinement of RaptorX-Contact models. Refinement performed using a protocol based on molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/nsp4.pdb
+pdbids:
+  -
+proteins:
+  - NSP4
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/nsp4_feig_RaptorX.yml
+++ b/data/models/nsp4_feig_RaptorX.yml
@@ -4,7 +4,6 @@ description: FeigLab refinement of RaptorX-Contact models. Refinement performed 
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/nsp4.pdb
 pdbids:
-  -
 proteins:
   - NSP4
 creator: Feig Computational Biophysics Lab

--- a/data/models/nsp6_feig.yml
+++ b/data/models/nsp6_feig.yml
@@ -1,0 +1,11 @@
+name: Refinement of nsp6 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Contact-based structure prediction using trRosetta. 10 models generated and the best scoring was refined through molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/nsp6.pdb
+pdbids:
+  -
+proteins:
+  - NSP6
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/nsp6_feig.yml
+++ b/data/models/nsp6_feig.yml
@@ -4,7 +4,6 @@ description: Contact-based structure prediction using trRosetta. 10 models gener
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/FeigLab/nsp6.pdb
 pdbids:
-  -
 proteins:
   - NSP6
 creator: Feig Computational Biophysics Lab

--- a/data/models/nsp6_feig_AlphaFold.yml
+++ b/data/models/nsp6_feig_AlphaFold.yml
@@ -1,0 +1,11 @@
+name: Refinement of AplhaFold nsp6 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: Physics-based refinement of Google DeepMind AlphaFold models from early March 2020. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/nsp6.pdb
+pdbids:
+  -
+proteins:
+  - NSP6
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/models/nsp6_feig_AlphaFold.yml
+++ b/data/models/nsp6_feig_AlphaFold.yml
@@ -4,7 +4,6 @@ description: Physics-based refinement of Google DeepMind AlphaFold models from e
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/AlphaFold/nsp6.pdb
 pdbids:
-  -
 proteins:
   - NSP6
 creator: Feig Computational Biophysics Lab

--- a/data/models/nsp6_feig_RaptorX.yml
+++ b/data/models/nsp6_feig_RaptorX.yml
@@ -4,7 +4,6 @@ description: FeigLab refinement of RaptorX-Contact models. Refinement performed 
 publication_doi: https://doi.org/10.1101/2020.03.25.008904
 pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/nsp6.pdb
 pdbids:
-  -
 proteins:
   - NSP6
 creator: Feig Computational Biophysics Lab

--- a/data/models/nsp6_feig_RaptorX.yml
+++ b/data/models/nsp6_feig_RaptorX.yml
@@ -1,0 +1,11 @@
+name: Refinement of RaptorX nsp6 by FeigLab
+url: https://github.com/feiglab/sars-cov-2-proteins
+description: FeigLab refinement of RaptorX-Contact models. Refinement performed using a protocol based on molecular dynamics (MD) simulations. See https://github.com/feiglab/sars-cov-2-proteins for a complete description of the process.
+publication_doi: https://doi.org/10.1101/2020.03.25.008904
+pdb_url: https://github.com/feiglab/sars-cov-2-proteins/blob/master/RaptorX/nsp6.pdb
+pdbids:
+  -
+proteins:
+  - NSP6
+creator: Feig Computational Biophysics Lab
+institution: Michigan State University

--- a/data/proteins/M_protein.yml
+++ b/data/proteins/M_protein.yml
@@ -1,0 +1,5 @@
+protein: M protein
+name: Membrane Glycoprotein
+description: Viral envelope component that plays a role in morphogenesis.
+organism: SARS-CoV-2
+interest: low

--- a/data/proteins/ORF10.yml
+++ b/data/proteins/ORF10.yml
@@ -1,0 +1,5 @@
+protein: ORF10
+name: Coronavirus Open Reading Frame 10
+description: Behaviour of this protein is uncertain/unclear.
+organism: SARS-CoV-2
+interest: low

--- a/data/proteins/ORF3a.yml
+++ b/data/proteins/ORF3a.yml
@@ -1,0 +1,5 @@
+protein: ORF3a
+name: Coronavirus Open Reading Frame 3a
+description: Forms homotetrameric potassium sensitive ion channels and may modulate virus release.
+organism: SARS-CoV-2
+interest: low

--- a/data/proteins/ORF6.yml
+++ b/data/proteins/ORF6.yml
@@ -1,0 +1,5 @@
+protein: ORF6
+name: Coronavirus Open Reading Frame 6
+description: Possible determinant of virus virulence.
+organism: SARS-CoV-2
+interest: low

--- a/data/proteins/ORF7b.yml
+++ b/data/proteins/ORF7b.yml
@@ -1,0 +1,5 @@
+protein: ORF7b
+name: Coronavirus Open Reading Frame 7b
+description: Behaviour of this protein is uncertain/unclear.
+organism: SARS-CoV-2
+interest: low

--- a/data/proteins/ORF8.yml
+++ b/data/proteins/ORF8.yml
@@ -1,0 +1,5 @@
+protein: ORF8
+name: Coronavirus Open Reading Frame 8
+description: Behaviour of this protein is uncertain/unclear.
+organism: SARS-CoV-2
+interest: low

--- a/data/structures/README.md
+++ b/data/structures/README.md
@@ -37,6 +37,12 @@ proteins: (one or more of the following options)
   - 3CLpro
   - PLpro
   - RdRP
+  - ORF3a
+  - ORF6
+  - ORF8
+  - ORF7b
+  - ORF10
+  - M protein
 targets: (one or more of the following options)
   - spike binding
   - spike cleavage

--- a/schema/validation.py
+++ b/schema/validation.py
@@ -37,6 +37,13 @@ class ValidProteins(str, Enum):
     Furin = 'Furin'
     IL6R = 'IL6R'
     p38 = 'p38'
+    ORF3a = 'ORF3a'
+    ORF6 = 'ORF6'
+    ORF7b = 'ORF7b'
+    ORF8 = 'ORF8'
+    ORF10 = 'ORF10'
+    Protein_3a = 'Protein 3a'
+    M_protein = 'M protein'
 
 
 class ValidTargets(str, Enum):

--- a/schema/validation.py
+++ b/schema/validation.py
@@ -42,7 +42,6 @@ class ValidProteins(str, Enum):
     ORF7b = 'ORF7b'
     ORF8 = 'ORF8'
     ORF10 = 'ORF10'
-    Protein_3a = 'Protein 3a'
     M_protein = 'M protein'
 
 

--- a/schema/validation.py
+++ b/schema/validation.py
@@ -110,7 +110,7 @@ class ModelsModel(BaseModel):
     description: str
     url: AnyUrl
     pdb_url: AnyUrl
-    pdbids: List[str]
+    pdbids: Optional[List[str]]
     proteins: List[ValidProteins]
     creator: str
     organization: Optional[str]


### PR DESCRIPTION
## Description
This PR is to re-add the feiglab data, hosted:
https://github.com/feiglab/sars-cov-2-proteins

They have been updated to the current schema. A few issues come up with this data that has not occurred yet. First, the current model schema specifies that a PDBid is used to help perform the linking and get data from the database. The pdb files for these models created through contact-based structure prediction using trRosetta and do not have listed PDBids associated to them (to the best of my knowledge). Currently this means they will fail validation and may cause difficulties in presenting them on the website.

To the best of my knowledge some of the proteins for these models are not currently hosted on the webpage.
* Membrane protein (M protein)
* ORF3a
* ORF6
* ORF8
* ORF7b
* ORF10
~~* Protein 3a~~ (Based on [Uniprot 3a](https://www.uniprot.org/uniprot/P59632) this has been removed and the model renamed to ORF3a_feig_AlphaFold.yml)


## Status
- [x] YAML file for each piece of data
- [x] Ready to go

## TODO
- [x] Protein yaml file for each of the new proteins
- [x] Adding the proteins to the validation script
- [x] Adding the proteins to the protein readme schema
