### PR TITLE
[WIP] Auto-populate the Proteins for validation, define protein subunits rigorously

### DIFF
--- a/data/molecules/Chloroquine.yml
+++ b/data/molecules/Chloroquine.yml
@@ -15,6 +15,6 @@ mechanism: The potential mechanisms for attacking the virus >
   By changing the acidity of the cells
   By inhibiting the ACE2 cellular receptor
   By activating the immune response
-protein:
+proteins:
   - ACE2
   - spike

--- a/data/molecules/EK1C4_fusion_inhibitor_peptide.yml
+++ b/data/molecules/EK1C4_fusion_inhibitor_peptide.yml
@@ -9,8 +9,13 @@ publications:
   - doi: 10.1038/s41422-020-0305-x
 target:
   - viral fusion
-protein:
+proteins:
   - spike
-  - S2
   - fusion core
-  - HR1
+protein_subunits:
+  spike:
+    S2:
+      - S2
+      - HR1
+    S1:
+      - RBD

--- a/data/molecules/Hydroxychloroquine.yml
+++ b/data/molecules/Hydroxychloroquine.yml
@@ -14,6 +14,6 @@ mechanism: Act primarily by>
   Altering endosomal pH and affecting virus-cell fusion
   By inhibiting the ACE2 cellular receptor
   By activating the immune response
-protein:
+proteins:
   - ACE2
   - spike

--- a/data/molecules/README.md
+++ b/data/molecules/README.md
@@ -13,7 +13,12 @@ description: (required)
 
 therapeutic: (required, one or more)
 target: (required, one or more)
-protein: (required, one or more)
+proteins: (required, one or more)
+protein_subunits: (optional)
+    {name_of_protien_from_proteins}:
+        {name_of_subunit_category}:
+            - subunit 1
+            - ...
 links: (optional)
   wikipedia: (optional) omit leading https://en.wikipedia.org/wiki/
   drugbank: (optional) omit leading https://www.drugbank.ca/drugs/

--- a/data/molecules/arbidol.yml
+++ b/data/molecules/arbidol.yml
@@ -12,6 +12,6 @@ target:
   - viral replication
   - viral fusion
 mechanism: May disrupt the binding of viral envelope protein to host cells and prevent viral entry to the target cell
-protein:
+proteins:
   - ACE2
   - spike

--- a/data/molecules/danoprevir.yml
+++ b/data/molecules/danoprevir.yml
@@ -10,7 +10,7 @@ links:
 target:
   - viral replication
 proteins:
-  - 3CL-PRO
+  - 3CLpro
 mechanism: Believed to inhibit the 3CL-PRO viral protease of SARS-CoV-2
 publications:
   - title: First Clinical Study Using HCV Protease Inhibitor Danoprevir to Treat Naïve and Experienced COVID-19 Patients

--- a/data/molecules/favipiravir.yml
+++ b/data/molecules/favipiravir.yml
@@ -10,5 +10,5 @@ links:
 target:
   - viral replication
 mechanism: Inhibits viral RNA-dependent RNA Polymerase
-protein:
+proteins:
   - RdRP

--- a/data/molecules/immunoglobulin.yml
+++ b/data/molecules/immunoglobulin.yml
@@ -12,5 +12,5 @@ links:
 target:
   - viral fusion
 mechanism: proposed to block viral Fc receptor activation by boosting endogenous neutralizing antibodies and preventing antibody-dependent enhancement of infection
-protein:
+proteins:
   - Fc receptor

--- a/data/molecules/lopinavir.yml
+++ b/data/molecules/lopinavir.yml
@@ -12,6 +12,6 @@ target:
   - PLpro protease activity
   - 3CLpro protease activity
 mechanism: Inhibits the viral proteases
-protein:
+proteins:
   - 3CLpro
   - PLpro

--- a/data/molecules/nivolumab.yml
+++ b/data/molecules/nivolumab.yml
@@ -12,4 +12,5 @@ links:
 target:
   - host immune response
 mechanism: Blocks PD-1 inhibitory signaling to T-cells
-protein: PD-1
+proteins:
+  - PD-1

--- a/data/molecules/remdesivir.yml
+++ b/data/molecules/remdesivir.yml
@@ -10,5 +10,5 @@ links:
 target:
   - viral replication
 mechanism: inhibitor of RNA-dependent RNA polymerase
-protein:
+proteins:
   - RdRP

--- a/data/molecules/tocilizumab.yml
+++ b/data/molecules/tocilizumab.yml
@@ -8,5 +8,5 @@ links:
 target:
   - host immune response
 mechanism: Targets soluble and membrane-bound IL-6 receptors to decrease immune and inflammatory responses
-protein:
+proteins:
   - IL6R

--- a/data/proteins/fusion.yml
+++ b/data/proteins/fusion.yml
@@ -3,3 +3,8 @@ name: Viral Spike Fusion Core
 description: Fusion core of the spike's S2 stalk. Includes the Heptad Repeats, HR1 and HR2
 organism: SARS-CoV-2
 interest: low
+subunits:
+  S2:
+    - S2
+    - HR1
+    - HR2

--- a/data/proteins/spike.yml
+++ b/data/proteins/spike.yml
@@ -9,8 +9,9 @@ target:
   - viral fusion
 subunits:
   S1:
-    - RBD (receptor binding domain)
+    - RBD # (receptor binding domain)
   S2:
+    - S2
     - S1/S2 cleavage site
     - Fusion
     - S2' cleavage site

--- a/data/structures/6lxt.yml
+++ b/data/structures/6lxt.yml
@@ -1,8 +1,11 @@
 pdbid: 6lxt
 proteins:
   - fusion core
-  - HR1
-  - HR2
+protein_subunits:
+  fusion core:
+    S2:
+      - HR1
+      - HR2
 organisms:
   - SARS-CoV-2
 targets:

--- a/data/structures/6m0j.yml
+++ b/data/structures/6m0j.yml
@@ -1,8 +1,11 @@
 pdbid: 6m0j
 proteins:
   - spike
-  - RBD
   - ACE2
+protein_subunits:
+  spike:
+    S1:
+      - RBD
 organisms:
   - SARS-CoV-2
   - human

--- a/data/structures/6m17.yml
+++ b/data/structures/6m17.yml
@@ -1,9 +1,12 @@
 pdbid: 6m17
 proteins:
   - spike
-  - RBD
   - ACE2
   - BoAT1
+protein_subunits:
+  spike:
+    S1:
+      - RBD
 organisms:
   - SARS-CoV-2
   - human

--- a/data/structures/6w41.yml
+++ b/data/structures/6w41.yml
@@ -3,7 +3,10 @@ targets:
   - spike binding
 proteins:
   - spike
-  - RBD
+protein_subunits:
+  spike:
+    S1:
+      - RBD
 therapeutics:
   - antibody
 annotation: Low resolution X-ray structure of human antibody CR3022 bound to the receptor binding domain (RBD) of the spike protein.

--- a/data/structures/README.md
+++ b/data/structures/README.md
@@ -11,9 +11,6 @@ Each entry has the following required and optional keys:
 pdbid: (required)
 proteins: (one or more of the following options)
   - spike
-  - RBD
-  - S1
-  - S2
   - ACE2
   - NSP1
   - NSP2
@@ -31,12 +28,15 @@ proteins: (one or more of the following options)
   - NSP14
   - NSP15
   - fusion core
-  - HR1
-  - HR2
   - TMPRSS2
   - 3CLpro
   - PLpro
   - RdRP
+protein_subunits: (optional)
+    {name_of_protien_from_proteins}:
+        {name_of_subunit_category}:
+            - subunit 1
+            - ...
 targets: (one or more of the following options)
   - spike binding
   - spike cleavage

--- a/data/targets/README.md
+++ b/data/targets/README.md
@@ -12,5 +12,10 @@ target: (required unique keyword)
 name: (required)
 description: (required)
 proteins: (required)
+protein_subunits: (optional)
+    {name_of_protien_from_proteins}:
+        {name_of_subunit_category}:
+            - subunit 1
+            - ...
 therapeutic_modalities: one or ore of [small molecule, antibody, peptide, vaccine]
 ```

--- a/data/targets/spike_binding.yml
+++ b/data/targets/spike_binding.yml
@@ -4,7 +4,11 @@ description: >
   The spike protein of SARS-CoV-2 binds to the ACE2 protein to initiate cell entry.
 proteins:
   - ACE2
-  - RBD
+  - spike
+protein_subunits:
+  spike:
+    S1:
+      - RBD
 therapeutic_modalities:
   - antibody
   - small molecule

--- a/themes/minimal/layouts/partials/thera-by-protein.html
+++ b/themes/minimal/layouts/partials/thera-by-protein.html
@@ -3,11 +3,11 @@
 {{ $localScratch.Set "map" dict }}
 
 {{ range $.Site.Data.molecules }}
-    {{ if .protein }}
-        {{ if reflect.IsSlice .protein }}
-            {{ $localScratch.Set "iter" .protein }}
+    {{ if .proteins }}
+        {{ if reflect.IsSlice .proteins }}
+            {{ $localScratch.Set "iter" .proteins }}
         {{ else }}
-            {{ $localScratch.Set "iter" (slice .protein) }}
+            {{ $localScratch.Set "iter" (slice .proteins) }}
         {{ end }}
 
         {{ $localScratch.Set "data" . }}

--- a/themes/minimal/layouts/partials/therapeutics-data.html
+++ b/themes/minimal/layouts/partials/therapeutics-data.html
@@ -48,11 +48,11 @@
 {{ end }}
 
 <!-- tag links to proteins involves in this target -->
-{{ if .data.protein }}
-  {{ if reflect.IsSlice .data.protein }}
-      {{ $localScratch.Set "iter" .data.protein }}
+{{ if .data.proteins }}
+  {{ if reflect.IsSlice .data.proteins }}
+      {{ $localScratch.Set "iter" .data.proteins }}
   {{ else }}
-      {{ $localScratch.Set "iter" (slice .data.protein) }}
+      {{ $localScratch.Set "iter" (slice .data.proteins) }}
   {{ end }}
   <p align="justify"><u>Known Protein Interactions:</u></p>
   {{ range $localScratch.Get "iter" }}


### PR DESCRIPTION
## Description
This is the start of having the validation script auto-populate the valid Proteins and subunits for those proteins. There are also a number of changes this introduces to schema and needs review.

* *Needs Review*: Adds a `protein_subunits` categories to most data types for specifying subunits in a regular way (valid cases also auto populated). This also _removes_ the RBD, S1, S2, HR1, and HR2 from the "proteins" categories. However, we still have the "fusion core" as a valid "protein." which clashes with the thought process here I think, but might be okay, hence why this needs reviewed.
* Changes the `protein` field of `molecules` to `proteins` to be consistent with the rest of the schemas

This is a work in progress [WIP] because the identification and cross linking of subunits on the site pages has not been done. However, I did not want to do those before the change to the schema is finalized.

cc @apayne97 @egoldber @jiayeguo @jchodera @Binikarki who have been developing most the schema up until now.

## Status
- [ ] Ready to go


