### PR TITLE
Adds links to CORD-19 and SWEETLEAD. Adds publication section to external resources

### DIFF
--- a/data/links/cord19.yml
+++ b/data/links/cord19.yml
@@ -1,0 +1,5 @@
+name: "CORD-19: COVID-19 Open Research Dataset"
+url: https://allenai.org/data/cord-19
+description: CORD-19 provides over 52,000 scholarly articles about COVID-19 and the coronavirus family of viruses for use by the research community. This dataset is updated weekly as new research is published in peer-reviewed publications and archives, such as bioRxiv, medRxiv and more.
+organization: Allen Institute for AI
+resources: publications

--- a/data/links/sweetlead.yml
+++ b/data/links/sweetlead.yml
@@ -1,0 +1,5 @@
+name: SWEETLEAD
+url: https://simtk.org/projects/sweetlead
+description: The SWEETLEAD database is a cheminformatics database of medicines, drugs, and herbal isolates.  It provides a resource for chemical structures and was built by pulling data from several public chemical databases.
+lab: Paul Novick and Vijay Pande
+resources: models

--- a/schema/validation.py
+++ b/schema/validation.py
@@ -71,6 +71,7 @@ class ValidInterest(str, Enum):
 class ResourcesEnum(str, Enum):
     structures = 'structures'
     models = 'models'
+    publications = 'publications'
 
 
 class ValidSimulations(str, Enum):

--- a/themes/minimal/layouts/links/single.html
+++ b/themes/minimal/layouts/links/single.html
@@ -7,27 +7,37 @@
     <div>
         <h2>{{ .Title }}</h2>
         <h4>{{ .Description }}</h4>
-
+        
+        
+        
         <h5 align="left">
         Data classification:
             <ul style="text-align:justify;">
                 {{ range slice "structures" "models"}}
                     {{ $data := index $.Site.Data.glossary . }}
-                    <li><a href="{{ $data.url }}"><b>{{ $data.term | title }}:</b></a> {{ $data.short }}</li>
+                    <li><a href="{{ delimit (slice "#ext" "res" (string $data.term) ) "_" }}"><b>{{ $data.term | title }}:</b></a> {{ $data.short }}</li>
                 {{ end }}
+                <li><a href="#ext_res_Publications"><b> Publications:</b></a> Databases containing pulications, peer-reviewed and pre-prints, relevant to COVID-19</li>
             </ul>
         </h5>
-
-        <h3> Structures </h3>
+        <hr class="hr-thick">
+        <h3 id="ext_res_Structures" > Structures </h3>
         {{ range $.Site.Data.links  }}
             {{ if eq .resources "structures" }}
                 {{ partial "links-data.html" (dict "links" . "context" $) }}
             {{ end }}
         {{ end }}
 
-        <h3> Models </h3>
+        <h3 id="ext_res_Models"> Models </h3>
         {{ range $.Site.Data.links  }}
             {{ if eq .resources "models" }}
+                {{ partial "links-data.html" (dict "links" . "context" $) }}
+            {{ end }}
+        {{ end }}
+        
+        <h3 id="ext_res_Publications"> Publications </h3>
+        {{ range $.Site.Data.links  }}
+            {{ if eq .resources "publications" }}
                 {{ partial "links-data.html" (dict "links" . "context" $) }}
             {{ end }}
         {{ end }}


### PR DESCRIPTION
## Description
Updates the data classifications section at the top of the external resources to include publications and to link to their relevant sections on the page.

Adds two new external resources, the CORD-19 dataset and the SWEETLEAD database.


## Status
- [x] YAML file for each piece of data
- [x] Ready to go
