### PR TITLE
Update marker logic so that preprint and published appear together when applicable

### DIFF
--- a/themes/minimal/layouts/partials/general-marker.html
+++ b/themes/minimal/layouts/partials/general-marker.html
@@ -3,12 +3,12 @@
 
 {{ $localScratch := newScratch }}
 
-{{ if $.publication }}
-  <a href="{{ $.publication | safeURL }}"><img src="/images/published.png" style="height:25px"></a>
-{{ else if and $.preprint (not (eq $.preprint "Submitted")) }}
+{{ if and .preprint (not (eq .preprint "Submitted")) }}
   <a href="{{ $.preprint | safeURL }}"><img src="/images/preprint.png" style="height:25px"></a>
-{{ else if and $.preprint (eq $.preprint "Submitted") }}
+{{ else if and (eq .preprint "Submitted") (not .publication) }}
   <img src="/images/preprint.png" style="height:25px">
-{{ else }}
+{{ end }}
 
+{{ if .publication }}
+  <a href="{{ $.publication | safeURL }}"><img src="/images/published.png" style="height:25px"></a>
 {{ end }}

--- a/themes/minimal/layouts/partials/marker-info-header.html
+++ b/themes/minimal/layouts/partials/marker-info-header.html
@@ -1,5 +1,5 @@
 <ul style="text-align:left">
     <li>Unpublished data with no preprints have no indicator</li>
-    <li>Data in a preprint or submitted for publication are given this <img src="/images/preprint.png" style="height:25px"> marker. If the preprint is available, it should work as a link</li>
+    <li>Data in a preprint or submitted for publication are given this <img src="/images/preprint.png" style="height:25px"> marker. If the preprint is available, it will always show and should work as a link</li>
     <li>Data published in a paper or accepted are given this <img src="/images/published.png" style="height:25px"> marker (i.e. has been approved by formal peer review) and should work as links.</li>
 </ul>

--- a/themes/minimal/layouts/partials/structure-marker.html
+++ b/themes/minimal/layouts/partials/structure-marker.html
@@ -18,14 +18,16 @@
 {{ end }}
 
 {{ $pub_link := $localScratch.Get "pub_link" }}
-{{ if and $pub_link (not (eq $pub_link "TBP")) }}
-  <a href="{{ $pub_link }}"><img src="/images/published.png" style="height:25px"></a>
-{{ else if $.publication }}
-  <a href="{{ $.publication | safeURL }}"><img src="/images/published.png" style="height:25px"></a>
-{{ else if and $.preprint (not (eq $.preprint "Submitted")) }}
-  <a href="{{ $.preprint | safeURL }}"><img src="/images/preprint.png" style="height:25px"></a>
-{{ else if and $.preprint (eq $.preprint "Submitted") }}
-  <img src="/images/preprint.png" style="height:25px">
-{{ else }}
 
+{{ if and .preprint (not (eq .preprint "Submitted")) }}
+  <a href="{{ $.preprint | safeURL }}"><img src="/images/preprint.png" style="height:25px"></a>
+{{ else if and (eq .preprint "Submitted") (and (not .publication) (or (not $pub_link) (eq $pub_link "TBP"))) }}
+  <!-- Preprint submitted, no publication, and (pub_link isnt real or pub_link is TBP) -->
+  <img src="/images/preprint.png" style="height:25px">
+{{ end }}
+
+{{ if and $pub_link (not (eq $pub_link "TBP")) }}
+  <a href="{{ $pub_link | safeURL }}"><img src="/images/published.png" style="height:25px"></a>
+{{ else if .publication }}
+  <a href="{{ .publication | safeURL }}"><img src="/images/published.png" style="height:25px"></a>
 {{ end }}


### PR DESCRIPTION
## Description
Changed the marker logic for publications as suggested at https://github.com/MolSSI/covid/pull/70#issuecomment-617999110

* If a preprint is available, it always shows up first.
* If a publication is available it shows up after the preprint (if there is one)
* If a preprint was in "submitted" status and a publication is available, then only the publication shows up.

## Status
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


