### PR TITLE
Rikenbdr data

### DIFF
--- a/data/models/3CLpro_rikenbdr.yml
+++ b/data/models/3CLpro_rikenbdr.yml
@@ -1,0 +1,12 @@
+name: "SARS-CoV-2 dimeric main protease without ligand based on PDB 6LU7"
+description: >
+  
+url: http://dx.doi.org/10.17632/vpps4vhryg
+model_type: GROMACS
+pdb_url: 
+pdbids: 
+  - 6LU7
+proteins: 
+  - 3CLpro
+creator: Teruhisa S. Komatsu, Yohei M. Koyama, Noriaki Okimoto, Gentaro Morimoto, Yousuke Ohno, Makoto Taiji
+organization: Riken Biosystems Dynamics Research

--- a/data/simulations/README.md
+++ b/data/simulations/README.md
@@ -34,7 +34,7 @@ size: (required) Size of trajectory file, please include units
 length: (required) elapsed real time trajectory covers, please include units
 ensemble: one of [NPT, NVT, NVE, Other]
 temperature: (required) in Kelvin, can be N/A
-pressure: (required) in Atm, can be N/A  
+pressure: (optional) in Atm  
 solvent: (required) can also be none or vacuum
 salinity: (optional) in Molar
 forcefields: (required) List of forcefields, can be simple names

--- a/data/simulations/rikenbdr_10us_every1ns_protein_snap.yml
+++ b/data/simulations/rikenbdr_10us_every1ns_protein_snap.yml
@@ -17,9 +17,9 @@ size: 340 MBs
 length: 10 µs
 ensemble: NVT
 temperature: 310
-pressure: N/A
+pressure: 
 solvent: TIP3P
-salinity: (optional) in Molar
+salinity: 
 forcefields:
     - amber99sb-ildn
 preprint: http://dx.doi.org/10.17632/vpps4vhryg

--- a/data/simulations/rikenbdr_10us_every1ns_protein_snap.yml
+++ b/data/simulations/rikenbdr_10us_every1ns_protein_snap.yml
@@ -1,0 +1,25 @@
+type: one of [docking, md, mc, md-cg, mc-cg]
+title: Riken BDR 10 Microsecond Trajectory Protein Snapshot every 1ns
+description: Single 10 microseconds trajectory of SARS-CoV-2 dimeric main protease, NVT at 310K, with the time step 2.5fs (more precisely, 2.500000409 fs). The starting structure was prepared based on `PDB 6LU7`, with `amber99sb-ildn` force field. The system is composed of 98,694 atoms in 9.98921 nm length cubic box with periodic boundary conditions. Simulation performed in aqueous solution with solvent forcefield `TIP3P`.
+creator: Teruhisa S. Komatsu, Yohei M. Koyama, Noriaki Okimoto, Gentaro Morimoto, Yousuke Ohno, Makoto Taiji
+organization: Riken Biosystems Dynamics Research
+models:
+    - 3CLpro_rikenbdr
+proteins:
+    - 3CLpro
+structures: 
+    - 6LU7
+rating: 
+files:
+    - https://covmme.molssi.org/data/rikenBDR/rikenBDR_trajs_0/main_protease/rikenBDR-Trajectory_sarscov2-10921231-structure/sarscov2-10921231-structure.tar
+trajectory: https://covmme.molssi.org/data/rikenBDR/rikenBDR_trajs_0/main_protease/rikenBDR-Trajectory_sarscov2-10921231-trajectory/sarscov2-10921231-protein/traj_protein_snap_every1ns.tar
+size: 340 MBs
+length: 10 µs
+ensemble: NVT
+temperature: 310
+pressure: N/A
+solvent: TIP3P
+salinity: (optional) in Molar
+forcefields:
+    - amber99sb-ildn
+preprint: http://dx.doi.org/10.17632/vpps4vhryg

--- a/data/simulations/rikenbdr_10us_every1ns_protein_snap.yml
+++ b/data/simulations/rikenbdr_10us_every1ns_protein_snap.yml
@@ -18,8 +18,9 @@ length: 10 µs
 ensemble: NVT
 temperature: 310
 pressure: 
-solvent: TIP3P
+solvent: Water
 salinity: 
 forcefields:
     - amber99sb-ildn
+    - TIP3P
 preprint: http://dx.doi.org/10.17632/vpps4vhryg

--- a/data/simulations/rikenbdr_10us_every1ns_protein_snap.yml
+++ b/data/simulations/rikenbdr_10us_every1ns_protein_snap.yml
@@ -1,4 +1,4 @@
-type: one of [docking, md, mc, md-cg, mc-cg]
+type: md
 title: Riken BDR 10 Microsecond Trajectory Protein Snapshot every 1ns
 description: Single 10 microseconds trajectory of SARS-CoV-2 dimeric main protease, NVT at 310K, with the time step 2.5fs (more precisely, 2.500000409 fs). The starting structure was prepared based on `PDB 6LU7`, with `amber99sb-ildn` force field. The system is composed of 98,694 atoms in 9.98921 nm length cubic box with periodic boundary conditions. Simulation performed in aqueous solution with solvent forcefield `TIP3P`.
 creator: Teruhisa S. Komatsu, Yohei M. Koyama, Noriaki Okimoto, Gentaro Morimoto, Yousuke Ohno, Makoto Taiji

--- a/data/simulations/rikenbdr_10us_every_200ps_protein_snap.yml
+++ b/data/simulations/rikenbdr_10us_every_200ps_protein_snap.yml
@@ -1,4 +1,4 @@
-type: one of [docking, md, mc, md-cg, mc-cg]
+type: md
 title: Riken BDR 10 Microsecond Trajectory Protein Snapshot every 200ps
 description: Single 10 microseconds trajectory of SARS-CoV-2 dimeric main protease, NVT at 310K, with the time step 2.5fs (more precisely, 2.500000409 fs). The starting structure was prepared based on `PDB 6LU7`, with `amber99sb-ildn` force field. The system is composed of 98,694 atoms in 9.98921 nm length cubic box with periodic boundary conditions. Simulation performed in aqueous solution with solvent forcefield `TIP3P`.
 creator: Teruhisa S. Komatsu, Yohei M. Koyama, Noriaki Okimoto, Gentaro Morimoto, Yousuke Ohno, Makoto Taiji

--- a/data/simulations/rikenbdr_10us_every_200ps_protein_snap.yml
+++ b/data/simulations/rikenbdr_10us_every_200ps_protein_snap.yml
@@ -1,0 +1,25 @@
+type: one of [docking, md, mc, md-cg, mc-cg]
+title: Riken BDR 10 Microsecond Trajectory Protein Snapshot every 200ps
+description: Single 10 microseconds trajectory of SARS-CoV-2 dimeric main protease, NVT at 310K, with the time step 2.5fs (more precisely, 2.500000409 fs). The starting structure was prepared based on `PDB 6LU7`, with `amber99sb-ildn` force field. The system is composed of 98,694 atoms in 9.98921 nm length cubic box with periodic boundary conditions. Simulation performed in aqueous solution with solvent forcefield `TIP3P`.
+creator: Teruhisa S. Komatsu, Yohei M. Koyama, Noriaki Okimoto, Gentaro Morimoto, Yousuke Ohno, Makoto Taiji
+organization: Riken Biosystems Dynamics Research
+models:
+    - 3CLpro_rikenbdr
+proteins:
+    - 3CLpro
+structures: 
+    - 6LU7
+rating: 
+files:
+    - https://covmme.molssi.org/data/rikenBDR/rikenBDR_trajs_0/main_protease/rikenBDR-Trajectory_sarscov2-10921231-structure/sarscov2-10921231-structure.tar
+trajectory: https://covmme.molssi.org/data/rikenBDR/rikenBDR_trajs_0/main_protease/rikenBDR-Trajectory_sarscov2-10921231-trajectory/sarscov2-10921231-protein/traj_protein_snap_every200ps.tar
+size: 1.7 GBs
+length: 10 µs
+ensemble: NVT
+temperature: 310
+pressure: N/A
+solvent: TIP3P
+salinity: (optional) in Molar
+forcefields:
+    - amber99sb-ildn
+preprint: http://dx.doi.org/10.17632/vpps4vhryg

--- a/data/simulations/rikenbdr_10us_every_200ps_protein_snap.yml
+++ b/data/simulations/rikenbdr_10us_every_200ps_protein_snap.yml
@@ -18,8 +18,9 @@ length: 10 µs
 ensemble: NVT
 temperature: 310
 pressure: 
-solvent: TIP3P
+solvent: Water
 salinity: 
 forcefields:
     - amber99sb-ildn
+    - TIP3P
 preprint: http://dx.doi.org/10.17632/vpps4vhryg

--- a/data/simulations/rikenbdr_10us_every_200ps_protein_snap.yml
+++ b/data/simulations/rikenbdr_10us_every_200ps_protein_snap.yml
@@ -17,9 +17,9 @@ size: 1.7 GBs
 length: 10 µs
 ensemble: NVT
 temperature: 310
-pressure: N/A
+pressure: 
 solvent: TIP3P
-salinity: (optional) in Molar
+salinity: 
 forcefields:
     - amber99sb-ildn
 preprint: http://dx.doi.org/10.17632/vpps4vhryg

--- a/data/simulations/rikenbdr_10us_system_snap.yml
+++ b/data/simulations/rikenbdr_10us_system_snap.yml
@@ -1,4 +1,4 @@
-type: one of [docking, md, mc, md-cg, mc-cg]
+type: md
 title: Riken BDR 10 Microsecond Trajectory System Snapshot every 10ns
 description: Single 10 microseconds trajectory of SARS-CoV-2 dimeric main protease, NVT at 310K, with the time step 2.5fs (more precisely, 2.500000409 fs). The starting structure was prepared based on `PDB 6LU7`, with `amber99sb-ildn` force field. The system is composed of 98,694 atoms in 9.98921 nm length cubic box with periodic boundary conditions. Simulation performed in aqueous solution with solvent forcefield `TIP3P`.
 creator: Teruhisa S. Komatsu, Yohei M. Koyama, Noriaki Okimoto, Gentaro Morimoto, Yousuke Ohno, Makoto Taiji

--- a/data/simulations/rikenbdr_10us_system_snap.yml
+++ b/data/simulations/rikenbdr_10us_system_snap.yml
@@ -17,9 +17,9 @@ size: 343 MBs
 length: 10 µs
 ensemble: NVT
 temperature: 310
-pressure: N/A
+pressure: 
 solvent: TIP3P
-salinity: (optional) in Molar
+salinity: 
 forcefields:
     - amber99sb-ildn
 preprint: http://dx.doi.org/10.17632/vpps4vhryg

--- a/data/simulations/rikenbdr_10us_system_snap.yml
+++ b/data/simulations/rikenbdr_10us_system_snap.yml
@@ -1,0 +1,25 @@
+type: one of [docking, md, mc, md-cg, mc-cg]
+title: Riken BDR 10 Microsecond Trajectory System Snapshot every 10ns
+description: Single 10 microseconds trajectory of SARS-CoV-2 dimeric main protease, NVT at 310K, with the time step 2.5fs (more precisely, 2.500000409 fs). The starting structure was prepared based on `PDB 6LU7`, with `amber99sb-ildn` force field. The system is composed of 98,694 atoms in 9.98921 nm length cubic box with periodic boundary conditions. Simulation performed in aqueous solution with solvent forcefield `TIP3P`.
+creator: Teruhisa S. Komatsu, Yohei M. Koyama, Noriaki Okimoto, Gentaro Morimoto, Yousuke Ohno, Makoto Taiji
+organization: Riken Biosystems Dynamics Research
+models:
+    - 3CLpro_rikenbdr
+proteins:
+    - 3CLpro
+structures: 
+    - 6LU7
+rating: 
+files:
+    - https://covmme.molssi.org/data/rikenBDR/rikenBDR_trajs_0/main_protease/rikenBDR-Trajectory_sarscov2-10421220-structure/sarscov2-10421220-structure.tar
+trajectory: https://covmme.molssi.org/data/rikenBDR/rikenBDR_trajs_0/main_protease/rikenBDR-Trajectory_sarscov2-10421220-trajectory/sarscov2-10421220-system/traj_system_snap_every10ns.tar
+size: 343 MBs
+length: 10 µs
+ensemble: NVT
+temperature: 310
+pressure: N/A
+solvent: TIP3P
+salinity: (optional) in Molar
+forcefields:
+    - amber99sb-ildn
+preprint: http://dx.doi.org/10.17632/vpps4vhryg

--- a/data/simulations/rikenbdr_10us_system_snap.yml
+++ b/data/simulations/rikenbdr_10us_system_snap.yml
@@ -18,8 +18,9 @@ length: 10 µs
 ensemble: NVT
 temperature: 310
 pressure: 
-solvent: TIP3P
+solvent: Water
 salinity: 
 forcefields:
     - amber99sb-ildn
+    - TIP3P
 preprint: http://dx.doi.org/10.17632/vpps4vhryg

--- a/data/structures/6LU7.yml
+++ b/data/structures/6LU7.yml
@@ -1,0 +1,8 @@
+pdbid: 6LU7
+proteins:
+  - 3CLpro
+targets:
+  - 3CLpro protease activity
+rating:
+organisms: 
+  - SARS-CoV-2

--- a/schema/validation.py
+++ b/schema/validation.py
@@ -171,9 +171,9 @@ class SimulationsModel(BaseModel):
     length: str
     ensemble: ValidEnsembles
     temperature: float
-    pressure: float
+    pressure: Optional[float]
     solvent: str
-    salinity: float
+    salinity: Optional[float]
     forcefields: List[str]
     references: Optional[List[str]]
     publication: Optional[AnyUrl]
@@ -186,6 +186,14 @@ class SimulationsModel(BaseModel):
                 raise ValueError(f'Rating must be on domain [1,5], is {v}')
         return v
 
+    # @validator('pressure')
+    # def pressure_valid(cls, v):
+        # if isinstance(v, str):
+            # if v.equals('N/A'):
+                # raise ValueError(f'Pressure must be a valid float or N/A, is {v}')
+        # if not isinstance(v, float):
+            # raise ValueError(f'Pressure must be a valid float or N/A, is {v}')
+        # return v
 
 class StructuresModel(BaseModel):
     pdbid: Optional[str]

--- a/themes/minimal/layouts/partials/model-entry.html
+++ b/themes/minimal/layouts/partials/model-entry.html
@@ -36,7 +36,8 @@
 
       <!-- Model and source PDBs -->
       <h5 align="left">
-      Model: <a href="{{ .model.url }}"><kbd class="alert-success">Model PDB</kbd></a>
+      
+      Model: <a href="{{ .model.url }}"><kbd class="alert-success">Files</kbd></a>
       |
       Source Structure PDBs:
       {{ range .model.pdbids }}

--- a/themes/minimal/layouts/partials/simulation-entry.html
+++ b/themes/minimal/layouts/partials/simulation-entry.html
@@ -60,7 +60,13 @@
                     {{ end }}
                     </td>
                     <td>{{ .simulation.solvent }}</td>
-                    <td>{{ .simulation.salinity }}</td>
+                    <td>
+                    {{ if not .simulation.salinity }}
+                        N/A
+                    {{ else }}
+                        {{ .simulation.salinity }}
+                    {{ end }}
+                    </td>
                     <td>{{ range .simulation.forcefields }} {{ . }}<br>{{ end }}</td>
                 </tr>
         </table>

--- a/themes/minimal/layouts/partials/simulation-entry.html
+++ b/themes/minimal/layouts/partials/simulation-entry.html
@@ -52,7 +52,13 @@
                     <td>{{ index $md_type_map .simulation.type }}</td>
                     <td>{{ .simulation.ensemble }}</td>
                     <td>{{ .simulation.temperature }}</td>
-                    <td>{{ .simulation.pressure }}</td>
+                    <td>
+                    {{ if not .simulation.pressure }}
+                        N/A
+                    {{ else }}
+                        {{ .simulation.pressure }}
+                    {{ end }}
+                    </td>
                     <td>{{ .simulation.solvent }}</td>
                     <td>{{ .simulation.salinity }}</td>
                     <td>{{ range .simulation.forcefields }} {{ . }}<br>{{ end }}</td>


### PR DESCRIPTION
## Description
This PR adds the trajectories produced by Riken BDR on the dimeric main protease.
There are 3 trajectories, along with an associated model and structure.

I have also updated the label for the model files from "Model PDB" to "Files" in general to reflect a larger variety of possible file types.

## Status
- [x] YAML file for each piece of data
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


