### PR TITLE
Restructure protein entry appearance.

### DIFF
--- a/themes/minimal/layouts/partials/protein-entry.html
+++ b/themes/minimal/layouts/partials/protein-entry.html
@@ -7,18 +7,18 @@
 
 <div class="col col-9">
 
-  <!-- protein name -->
-  <h3 align="left" class="anchor" id="{{ .protein.name | anchorize }}"><b>{{ .protein.name }}</b></h3>
+    <!-- protein name -->
+    <h3 align="left" class="anchor" id="{{ .protein.name | anchorize }}"><b>{{ .protein.name }}</b></h3>
 
-  <!-- protein description -->
-  <h4 align="justify">{{ .protein.description | markdownify }}</h4>
+    <!-- protein description -->
+    <h4 align="justify">{{ .protein.description | markdownify }}</h4>
 
-  <!-- illustrative structure image -->
-  {{ with .protein.image }} <p><img width=200 src="/{{ . }}"></p> {{ end }}
+    <!-- illustrative structure image -->
+    {{ with .protein.image }} <p><img width=200 src="/{{ . }}"></p> {{ end }}
 
-  {{ range (index ($localScratch.Get "thera_by_protein") (.protein.protein) ) }}
-    <a href='{{ index ($localScratch.Get "thera_map") . }}'><kbd class="alert-success">{{ . | title }}</kbd></a>
-  {{ end }}
+    {{ range (index ($localScratch.Get "thera_by_protein") (.protein.protein) ) }}
+        <a href='{{ index ($localScratch.Get "thera_map") . }}'><kbd class="alert-success">{{ . | title }}</kbd></a>
+    {{ end }}
 
   <!-- top (useful) structures containing this protein -->
   <h4 align="left">Top Structural Data: <a href='{{ $localScratch.Get "BaseURL" }}/structures/#{{ .protein.name | anchorize }}'>[See All]</a></h4>
@@ -64,6 +64,7 @@
 
   <!-- top (useful) models containing this protein -->
   <h4 align="left">Top Models: <a href='{{ $localScratch.Get "BaseURL" }}/models/#{{ .protein.name | anchorize }}'>[See All]</a></h4>
+  <h5 align="left">
     <!-- Determine if there are known models -->
   {{ $localScratch.Set "postedModels" 0 }}
   {{ range sort .context.Site.Data.models "rating" "desc" }}
@@ -89,20 +90,23 @@
   {{ if eq ($localScratch.Get "postedModels") (0) }}
     <p>---</p>
   {{ end }}
-
+  </h5>
     <h4 align="left"> Top Simulations: <a href='{{ $localScratch.Get "BaseURL" }}/simulations/#{{ .protein.name | anchorize }}'>[See All]</a></h4>
+    <h5 align="left">
     {{ $localScratch.Set "postedSim" 0 }}
     {{ range sort .context.Site.Data.simulations "rating" "desc" }}
         {{ $sim := . }}
         {{ if and (in .proteins $.protein.protein) (lt ($localScratch.Get "postedSim") 2) }}
         <!-- TODO: Map the anchor to *a* target instead of just the protein heade-->
-            <a href='{{ $localScratch.Get "BaseURL" }}/simulations/#{{ $.protein.name | anchorize }}'><kbd class="alert-secondary">{{ $sim.title}}</kbd></a>
-            {{ partial "general-marker" $sim }}
-            <!-- Add to the counter -->
-            {{ $localScratch.Set "postedSim" (add ($localScratch.Get "postedSim") 1 )}}
+            <p>
+                <a href='{{ $localScratch.Get "BaseURL" }}/simulations/#{{ $.protein.name | anchorize }}'><kbd class="alert-secondary">{{ $sim.title}}</kbd></a>
+                {{ partial "general-marker" $sim }}
+                <!-- Add to the counter -->
+                {{ $localScratch.Set "postedSim" (add ($localScratch.Get "postedSim") 1 )}}
+            </p>
         {{ end }}
     {{ end }}
-
+    </h5>
   <!-- TODO: Add most useful molecules/bioassay data? -->
 
   <hr>

--- a/themes/minimal/layouts/partials/protein-entry.html
+++ b/themes/minimal/layouts/partials/protein-entry.html
@@ -58,7 +58,7 @@
      {{ end }}
   {{ end }}
   {{ if eq ($localScratch.Get "postedStruct") (0) }}
-    <p>---</p>
+    <h5 align="left"><p>---</p><h5>
   {{ end }}
 
 


### PR DESCRIPTION
## Description
Cleans up the protein entry partial to have left justified paragraphed lists for the links.

## Status
- [ ] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


