### PR TITLE
Make NSP13 Active and call it Helicase

### DIFF
--- a/data/models/QHD43415_12.yml
+++ b/data/models/QHD43415_12.yml
@@ -1,10 +1,10 @@
-name: NSP13 by Yang Zhang lab
+name: Helicase (NSP13) by Yang Zhang lab
 description: model from deep learning contact-map assisted C-I-TASSER structure simulation
 url: https://zhanglab.ccmb.med.umich.edu/COVID-19/
 pdb_url: https://zhanglab.ccmb.med.umich.edu/COVID-19/QHD43415_12.pdb.gz
 pdbids:
 proteins:
-  - NSP13
+  - Helicase
 creator: Chengxin Zhang, Wei Zheng, Xiaoqiang Huang, Eric W. Bell, Xiaogen Zhou, Yang Zhang
 organization: Depeartment of Computational Medicine and Bioinformatics
 institution: University of Michigan

--- a/data/proteins/helicase.yml
+++ b/data/proteins/helicase.yml
@@ -1,0 +1,8 @@
+protein: Helicase
+name: Helicase coronavirus nonstructural protein 13 (NSP13)
+description: >
+  The NSP13 SARS sequence is conserved and helicase activity is necessary for COVID replication.
+  Helicase inhibition has been used for virus (HSV-amenavir) and cancer treatment (eIF41, RocA rocaglamides) and
+  has gained interested in a potential disrupting target.
+organism: SARS-CoV-2
+interest: active

--- a/data/proteins/nsp13.yml
+++ b/data/proteins/nsp13.yml
@@ -1,5 +1,0 @@
-protein: NSP13
-name: Coronavirus nonstructural protein 13
-description: Suppressor of host genome expression
-organism: SARS-CoV-2
-interest: low

--- a/data/structures/README.md
+++ b/data/structures/README.md
@@ -30,7 +30,7 @@ proteins: (one or more of the following options)
   - NSP10
   - NSP11
   - NSP12
-  - NSP13
+  - Helicase
   - NSP14
   - NSP15
   - fusion core

--- a/data/targets/inhibition_of_nsp13_helicase_activity.yml
+++ b/data/targets/inhibition_of_nsp13_helicase_activity.yml
@@ -3,7 +3,7 @@ name: inhibition of nsp13 helicase activity
 description: >
   Nsp13, nonstructural protein 13 has multiple functions with an N-terminal metal binding domain (MBD) and a helicase domain (Hel). The nsp13 SARS sequence is conserved and helicase activity is necessary for COVID replication. While this is an attractive target for viral inhibition, there are few reports on nsp13 inhibitors. Helicase inhibition has been used for virus (HSV-amenavir) and cancer treatment (eIF41, RocA rocaglamides), but likely due to its inherent flexibility, inhibitor design is challenging and high throughput screen hits are generally DNA binding artifacts.
 proteins:
-  - NSP13
+  - Helicase
 therapeutic_modalities:
   - small molecule
 papers: 

--- a/schema/validation.py
+++ b/schema/validation.py
@@ -21,7 +21,7 @@ class ValidProteins(str, Enum):
     NSP9 = 'NSP9'
     NSP10 = 'NSP10'
     NSP11 = 'NSP11'
-    NSP13 = 'NSP13'
+    Helicase = 'Helicase'
     NSP14 = 'NSP14'
     NSP15 = 'NSP15'
     NSP16 = 'NSP16'

--- a/themes/minimal/layouts/proteins/single.html
+++ b/themes/minimal/layouts/proteins/single.html
@@ -43,6 +43,7 @@
         <area shape="poly" coords="500,489, 501,501, 623,500, 593,423, 564,431" href='{{ $pmap.NSP8 }}' alt="nsp8">
         <area shape="rect" coords="570,350, 646,429" href='{{ $pmap.NSP10 }}' alt="nsp10">
         <area shape="poly" coords="873,386, 874,395, 876,530, 979,530, 978,466, 910,385" href='{{ $pmap.spike }}' alt="spike">
+        <area shape="rect" coords="657,339, 744,413" href='{{ $pmap.Helicase }}' alt="Helicase">
     </map>
 </main>
 


### PR DESCRIPTION
## Description
With the new interest in the Helicase protein, we have decided to bump it into the active category and call it `Helicase` as its ID instead of `NSP13`


## Status
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


