### PR TITLE
Cleanup appearance on Target page

### DIFF
--- a/themes/minimal/layouts/partials/target-entry.html
+++ b/themes/minimal/layouts/partials/target-entry.html
@@ -18,18 +18,22 @@
 
   <!-- tag links to proteins involves in this target -->
   <h4 align="left">Protein targets:</h4>
+  <h5 align="left">
   {{ range .context.proteins }}
     <a href='{{ index ($localScratch.Get "protein_map") . }}'><kbd class="bg-primary">{{ . }}</kbd></a>
   {{ end }}
+  </h5>
 
   <!-- key therapeutics -->
   {{ if .context.therapeutic_modalities }}
     <div>
     <h4 align="left">Potential therapeutic modalities:</h4>
+    <h5 align="left">
       {{ range .context.therapeutic_modalities }}
        <!-- NOTE: hyperlinks do not correctly link up to the right anchor point yet -->
        <a href='{{ index ($localScratch.Get "thera_map") . }}'><kbd class="alert-success">{{ . | title }}</kbd></a>
       {{ end }}
+    </h5>
     </div>
   {{ end }}
 
@@ -54,7 +58,7 @@
   </ul>
   {{ end }}
 
-  - - -
+  <hr>
 
 
 </div>

--- a/themes/minimal/layouts/targets/single.html
+++ b/themes/minimal/layouts/targets/single.html
@@ -23,14 +23,14 @@
         </h5>
     </div>
 
-    <hr>
+    <hr class="hr-thick">
 
     <!-- List all targets from data/targets/ -->
     {{ range $.Site.Data.targets }}
        {{ partial "target-entry" (dict "context" . "protein_map" ($localScratch.Get "protein_map") "thera_map" ($localScratch.Get "thera_map") )}}
     {{ end }}
 
-    <hr>
+    <hr class="hr-thick">
 
 </main>
 


### PR DESCRIPTION
## Description
Applies left alignment to lists and updates to breaks between entries to be consistent with other pages.


## Status
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


