### PR TITLE
Compacting entry partials.

### DIFF
--- a/themes/minimal/layouts/partials/model-entry.html
+++ b/themes/minimal/layouts/partials/model-entry.html
@@ -10,48 +10,48 @@
 <div class="col col-9">
 
       <!-- Model name -->
-      <h3 class="anchor" id='{{ print ( .model.name | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize)}}'>
+      <h4 align="center" class="anchor" id='{{ print ( .model.name | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize)}}'>
           {{ .model.name }}
           {{ with .model.rating }} {{ range $i, $sequence := (seq .) }}★{{ end }} {{ end }}
           {{ partial "general-marker" .model }}
-      </h3>
+      </h4>
 
       <!-- Author -->
-      <h5>{{ .model.creator }}</h5>
+      <h5 align="center">{{ .model.creator }}</h5>
 
       <!-- Proteins represented -->
+      <h5 align="left"><b>Represented Proteins: </b>
       {{ range $pname := .model.proteins }}
          {{ $plink := print ($localScratch.Get "context").Site.BaseURL "/proteins/#" ( $pname | anchorize) }}
          <a href="{{ $plink }}"><kbd class="bg-primary" style="">{{ $pname }}</kbd></a>
       {{ end }}
-
-      <!-- Show 3D structure using 3Dmol.js : see https://3dmol.csb.pitt.edu/ -->
-      {{ if .model.pdb_url }}
-          {{ if in (slice 5 ) .model.rating }}
-            <div align="center" style="height: 400px; width: 400px; position: relative; margin-top: 0px; margin-bottom: 0px; margin-left: auto; margin-right: auto;" class='viewer_3Dmoljs' data-href='{{ .model.pdb_url }}' data-backgroundcolor='0xffffff' data-style='cartoon:color~spectrum'></div>
-          {{ else }}
-            <div><h4><a href='http://3Dmol.csb.pitt.edu/viewer.html?url={{ .model.pdb_url }}&type=pdb&style=cartoon:color~spectrum'>See the Model in 3DMol.js</a></h4></div>
-          {{ end }}
-      {{ end }}
+      </h5>
 
       <!-- Model and source PDBs -->
       <h5 align="left">
       
-      Model: <a href="{{ .model.url }}"><kbd class="alert-success">Files</kbd></a>
-      |
-      Source Structure PDBs:
+      <b>Model: </b><a href="{{ .model.url }}"><kbd class="alert-success">Files</kbd></a>
+      <b>|
+      Source Structure PDBs:</b>
       {{ range .model.pdbids }}
         {{ $pdb := upper . }}
         {{ $url := print "https://www.rcsb.org/structure/" $pdb }}
         <a href="{{ $url }}"><kbd class="alert-warning">{{ $pdb }}</kbd></a>
       {{ end }}
+      <!-- Show 3D structure using 3Dmol.js : see https://3dmol.csb.pitt.edu/ -->
+      {{ if .model.pdb_url }}
+          {{ if in (slice 5 ) .model.rating }}
+            <div align="center" style="height: 400px; width: 400px; position: relative; margin-top: 0px; margin-bottom: 0px; margin-left: auto; margin-right: auto;" class='viewer_3Dmoljs' data-href='{{ .model.pdb_url }}' data-backgroundcolor='0xffffff' data-style='cartoon:color~spectrum'></div>
+          {{ else }}
+            <b>| Visualize: </b><a href='http://3Dmol.csb.pitt.edu/viewer.html?url={{ .model.pdb_url }}&type=pdb&style=cartoon:color~spectrum'><kbd class="alert-warning">3DMol.js</kbd></a>
+          {{ end }}
+      {{ end }}
       </h5>
-
-
+      
       <!-- Model description -->
-      <h4 align="justify">{{ .model.description | markdownify }}</h4>
+      <h5 align="justify">{{ .model.description | markdownify }}</h5>
 
-        <h4 align="left"> Simulations:</h4>
+        <h5 align="left"><b>Simulations:</b></h5>
         {{ $localScratch.Set "postedSim" 0 }}
         {{ range $mname, $mdata := .context.Site.Data.models }}
             {{ if eq $mdata.name $.model.name }}

--- a/themes/minimal/layouts/partials/protein-entry.html
+++ b/themes/minimal/layouts/partials/protein-entry.html
@@ -8,10 +8,10 @@
 <div class="col col-9">
 
     <!-- protein name -->
-    <h3 align="left" class="anchor" id="{{ .protein.name | anchorize }}"><b>{{ .protein.name }}</b></h3>
+    <h4 align="center" class="anchor" id="{{ .protein.name | anchorize }}"><b>{{ .protein.name }}</b></h4>
 
     <!-- protein description -->
-    <h4 align="justify">{{ .protein.description | markdownify }}</h4>
+    <h5 align="justify">{{ .protein.description | markdownify }}</h5>
 
     <!-- illustrative structure image -->
     {{ with .protein.image }} <p><img width=200 src="/{{ . }}"></p> {{ end }}
@@ -21,7 +21,7 @@
     {{ end }}
 
   <!-- top (useful) structures containing this protein -->
-  <h4 align="left">Top Structural Data: <a href='{{ $localScratch.Get "BaseURL" }}/structures/#{{ .protein.name | anchorize }}'>[See All]</a></h4>
+  <h5 align="left"><b>Top Structural Data: </b><a href='{{ $localScratch.Get "BaseURL" }}/structures/#{{ .protein.name | anchorize }}'>[See All]</a></h5>
   {{ $protein_id := .protein.protein }}
   {{ $localScratch.Set "protein_id" $protein_id }}
   {{ $localScratch.Set "postedStruct" 0 }}
@@ -63,7 +63,7 @@
 
 
   <!-- top (useful) models containing this protein -->
-  <h4 align="left">Top Models: <a href='{{ $localScratch.Get "BaseURL" }}/models/#{{ .protein.name | anchorize }}'>[See All]</a></h4>
+  <h5 align="left"><b>Top Models: </b><a href='{{ $localScratch.Get "BaseURL" }}/models/#{{ .protein.name | anchorize }}'>[See All]</a></h5>
   <h5 align="left">
     <!-- Determine if there are known models -->
   {{ $localScratch.Set "postedModels" 0 }}
@@ -91,7 +91,7 @@
     <p>---</p>
   {{ end }}
   </h5>
-    <h4 align="left"> Top Simulations: <a href='{{ $localScratch.Get "BaseURL" }}/simulations/#{{ .protein.name | anchorize }}'>[See All]</a></h4>
+    <h5 align="left"><b>Top Simulations: </b><a href='{{ $localScratch.Get "BaseURL" }}/simulations/#{{ .protein.name | anchorize }}'>[See All]</a></h5>
     <h5 align="left">
     {{ $localScratch.Set "postedSim" 0 }}
     {{ range sort .context.Site.Data.simulations "rating" "desc" }}

--- a/themes/minimal/layouts/partials/simulation-entry.html
+++ b/themes/minimal/layouts/partials/simulation-entry.html
@@ -11,19 +11,17 @@
 <div class="col col-9">
 
         <!-- Model name -->
-        <h3 class="anchor" id='{{ print ( .simulation.title | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize)}}'>
+        <h4 class="anchor" id='{{ print ( .simulation.title | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize)}}'>
             {{ .simulation.title }}
             {{ if .simulation.length }}
             ({{ .simulation.length }} )
             {{ end }}
             {{ with .simulation.rating }} {{ range $i, $sequence := (seq .) }}★{{ end }} {{ end }}
             {{ partial "general-marker" .simulation }}
-        </h3>
-
-        <h5>{{ .simulation.description | markdownify }}</h5>
-
-        <!-- Author -->
-        <h4>{{ .simulation.creator }}</h4>
+        </h4>
+        
+<!-- Author -->
+        <h5>{{ .simulation.creator }}</h5>
         {{ if .simulation.organization }}
         <p>Organization: {{ .simulation.organization }}</p>
         {{ end }}
@@ -33,6 +31,10 @@
         {{ if .simulation.lab }}
         <p>Lab: {{ .simulation.lab }}</p>
         {{ end }}
+        
+        <h5 align="left">{{ .simulation.description | markdownify }}</h5>
+
+        
 
         <!-- Physical Data -->
         <table class="table text-center-row">
@@ -71,8 +73,8 @@
                 </tr>
         </table>
 
-        <h4 align="left">
-            Input and Supporting Files:
+        <h5 align="left">
+            <b>Input and Supporting Files:</b>
             {{ if .simulation.files }}
                 {{ range (seq (len .simulation.files)) }}
                     <a href="{{ index $.simulation.files (sub . 1) }}"><kbd class="alert-secondary">[.]</kbd></a>
@@ -80,41 +82,41 @@
             {{ else }}
                 ---
             {{ end }}
-        </h4>
+        </h5>
 
-        <h4 align="left">
-            Trajectory:
+        <h5 align="left">
+            <b>Trajectory:</b>
             {{ if .simulation.trajectory }}
                 <a href="{{ .simulation.trajectory }}"><kbd class="alert-secondary">Get Trajectory ({{.simulation.size}})</kbd></a>
             {{ else }}
                 ---
             {{ end }}
-        </h4>
+        </h5>
 
         <!-- Proteins represented -->
-        <h4 align="left">
-            Represented Proteins:
+        <h5 align="left">
+            <b>Represented Proteins:</b>
             {{ range .simulation.proteins }}
                 <a href='{{ index ($localScratch.Get "protein_map") . }}'><kbd class="bg-primary">{{ . }}</kbd></a> 
             {{ else }}
                 ---
             {{ end }}
-        </h4>
+        </h5>
 
         <!-- Structures represented -->
-        <h4 align="left">
-            Represented Structures:
+        <h5 align="left">
+            <b>Represented Structures:</b>
             {{ range .simulation.structures }}
                 {{ $anchor := print ( . | upper | anchorize) "-" ( $.protein | anchorize) }}
                 <a href='{{ $.context.Site.BaseURL }}/structures/#{{ $anchor }}'><kbd class="alert-danger">{{.}}</kbd></a>
             {{ else }}
                 ---
             {{ end }}
-        </h4>
+        </h5>
 
         <!-- Models represented -->
-        <h4 align="left">
-            Models:
+        <h5 align="left">
+            <b>Models:</b>
             {{ range .simulation.models }}
                 {{ $model := . }}
                 {{ range $mname, $mdata := $.context.Site.Data.models }}
@@ -126,7 +128,7 @@
             {{ else }}
                 ---
             {{ end }}
-        </h4>
+        </h5>
 
         <!-- TODO: Include references in an accordion -->
 

--- a/themes/minimal/layouts/partials/structure-entry.html
+++ b/themes/minimal/layouts/partials/structure-entry.html
@@ -45,13 +45,13 @@
 
 
   <!-- Structure name -->
-  <h3 align="left" class="anchor" id='{{ print ($pdb | anchorize) "-" ( .protein | anchorize) }}'>
+  <h4 align="center" class="anchor" id='{{ print ($pdb | anchorize) "-" ( .protein | anchorize) }}'>
     <b>{{ $title }} {{ with .structure.rating }} {{ range $i, $sequence := (seq .) }}★{{ end }} {{ end }} {{ partial "structure-marker" .structure }} </b>
-  </h3>
+  </h4>
 
   <!-- Structure Annotation -->
   {{ if not (in ( $title | lower) (.structure.annotation | lower) ) }}
-    <h4 align="justify">Additional: {{ .structure.annotation }}</h4>
+    <h5 align="justify">Additional: {{ .structure.annotation }}</h5>
   {{ end }}
 
   <!-- illustrative structure image(s) -->
@@ -72,10 +72,8 @@
   {{ end }}
   </p>
 
-  <h4 align="left"> Structure Data and Links </h4>
+  <h5 align="left"><b>Structure Data and Links: </b>
   {{ $view3d := (printf "https://www.rcsb.org/3d-view/%s/1" $pdb) }} <!-- PDB viewer -->
-  <h5 align="left">
-  <p>
     {{ if .unpublished_pdbid }}
       Unpublished PDB (not on RCSB)
     {{ else }}
@@ -89,10 +87,11 @@
         {{ end }}
       {{ end }}
     {{ end }}
-  </p>
+    </h5>
+    <h5 align="left">
   {{ if $method }}
     <p>
-    Experimental Method: {{ $method }}
+    <b>Experimental Method: </b>{{ $method }}
     {{ if $resolution }}
       | Resolution: {{ $resolution }} Å
     {{ end }}
@@ -101,7 +100,7 @@
 </h5>
   <!-- Determine if there are known models -->
   {{ $localScratch.Set "postedModels" 0 }}
-  <h4 align="left"> Top Two Models: </h4>
+  <h5 align="left"><b>Top Two Models: </b></h5>
   {{ range sort .context.Site.Data.models "rating" "desc" }}
     {{ $localScratch.Set "model" . }}
     <!-- This PDB is in the given model and we have not posted more than 1 -->
@@ -125,27 +124,24 @@
     <h5 align="left"><p>---</p></h5>
   {{ end }}
 
-  <h4 align="left"> Known Target Modalities: </h4>
+  <h5 align="left"><b>Known Target Modalities:</b><!--</h5>
   <h5 align="left">
-  <p>
+  <p>-->
   {{ $targets := partial "ensure-slice" .structure.targets }}
   {{ range $targets }}
     <a href='{{ (index ($localScratch.Get "target_map") .).link }}'><kbd class="item-tag">{{ (index ($localScratch.Get "target_map") .).name | title }}</kbd></a>
   {{ end }}
-  </p>
+  <!--</p>-->
   </h5>
 
-  <h4 align="left"> Related Proteins: </h4>
-  <h5 align="left">
-  <p>
+  <h5 align="left"><b>Related Proteins:</b>
   {{ $proteins := partial "ensure-slice" .structure.proteins }}
   {{ range $proteins }}
     <a href='{{ index ($localScratch.Get "protein_map") . }}'><kbd class="bg-primary">{{ . }}</kbd></a>
   {{ end }}
-  </p>
   </h5>
 
-  <h4 align="left"> Top Simulations: <a href='{{ $.context.Site.BaseURL }}/simulations/#{{ $.protein | anchorize }}'>[See All]</a></h4>
+  <h5 align="left"><b>Top Simulations:</b><a href='{{ $.context.Site.BaseURL }}/simulations/#{{ $.protein | anchorize }}'>[See All]</a></h5>
     {{ $localScratch.Set "postedSim" 0 }}
     {{ range sort .context.Site.Data.simulations "rating" "desc" }}
         {{ $sim := . }}

--- a/themes/minimal/layouts/partials/target-entry.html
+++ b/themes/minimal/layouts/partials/target-entry.html
@@ -11,14 +11,13 @@
 <div class="col col-9">
 
   <!-- target name -->
-  <h3 class="anchor" id="{{.context.name | anchorize }}"><b>{{ .context.name }}</b><img width=30 src="/images/sars-cov-2-thumbnail.jpg"></h3>
+  <h4 class="anchor" id="{{.context.name | anchorize }}"><b>{{ .context.name }}</b><img width=30 src="/images/sars-cov-2-thumbnail.jpg"></h4>
 
   <!-- target description -->
   <p align="justify">{{ .context.description | markdownify }}</p>
 
   <!-- tag links to proteins involves in this target -->
-  <h4 align="left">Proteins affected:</h4>
-  <h5 align="left">
+  <h5 align="left"><b>Proteins affected:</b>
   {{ range .context.proteins }}
     <a href='{{ index ($localScratch.Get "protein_map") . }}'><kbd class="bg-primary">{{ . }}</kbd></a>
   {{ end }}
@@ -27,25 +26,25 @@
   <!-- key therapeutics -->
   {{ if .context.therapeutic_modalities }}
     <div>
-    <h4 align="left">Potential therapeutic modalities:</h4>
-    <h5 align="left">
+    <h5 align="left"><b>Potential therapeutic modalities:</b><!--</h5>
+    <h5 align="left">-->
       {{ range .context.therapeutic_modalities }}
        <!-- NOTE: hyperlinks do not correctly link up to the right anchor point yet -->
        <a href='{{ index ($localScratch.Get "thera_map") . }}'><kbd class="alert-success">{{ . | title }}</kbd></a>
       {{ end }}
-    </h5>
+    <!--</h5>-->
     </div>
   {{ end }}
 
 
   <!-- Key publications -->
   {{ if .context.papers }}
-  <h4 align="left">Key publications:</h4>
+  <h5 align="left"><b>Key publications:</b></h5>
   <ul>
     {{ range .context.papers }}
       <!-- TODO: Pull more information about these publications automagically -->
       <li>
-        <div align="justify"><b>{{ .title }}</b>
+        <div align="justify">{{ .title }}
         {{ if .doi }}
           <a href="http://doi.org/{{ .doi }}"> <kbd class="alert-info">[DOI]</kbd> </a>
         {{ end }}

--- a/themes/minimal/layouts/partials/therapeutics-data.html
+++ b/themes/minimal/layouts/partials/therapeutics-data.html
@@ -6,7 +6,7 @@
 {{ $localScratch.Set "target_map" .target_map }}
 
 <!-- Molecule Title -->
-<h4 align="justify">{{ .data.name | title }}</h4>
+<h4 align="center">{{ .data.name | title }}</h4>
 
 {{ with .data.links.drugbank }}
     <img src="https://www.drugbank.ca/structures/{{ . }}/thumb.svg">
@@ -16,11 +16,10 @@
 <p align="justify">{{ .data.description | markdownify }}</p>
 
 <!-- Molecule mechanism -->
-<p align="justify"><u>Mechanism:</u> {{ .data.mechanism }}</p>
+<p align="justify"><b>Mechanism: </b>{{ .data.mechanism }}</p>
 
 {{ if .data.links }}
-  <p align="justify"><u>Read more about it:</u></p></h5>
-  <h5 align="left">
+  <h5 align="left"><b>Read more about it:</b>
   {{ if .data.links.wikipedia }}
     <a href='https://en.wikipedia.org/wiki/{{ .data.links.wikipedia }}'><kbd class="alert-info">Wikipedia</kbd></a>
   {{ end }}
@@ -43,8 +42,8 @@
   {{ else }}
       {{ $localScratch.Set "iter" (slice .data.target) }}
   {{ end }}
-  <p align="justify"><u>Targeting Modalities:</u></p>
-  <h5 align="left">
+  <h5 align="left"><b>Targeting Modalities:</b>
+  
   {{ range $localScratch.Get "iter" }}
     <a href='{{ (index ($localScratch.Get "target_map") .).link }}'><kbd class="item-tag">{{ . | title}}</kbd></a>
   {{ end }}
@@ -58,8 +57,8 @@
   {{ else }}
       {{ $localScratch.Set "iter" (slice .data.protein) }}
   {{ end }}
-  <p align="justify"><u>Known Protein Interactions:</u></p>
-  <h5 align="left">
+  <h5 align="left"><b>Known Protein Interactions:</b>
+  
   {{ range $localScratch.Get "iter" }}
     <a href='{{ index ($localScratch.Get "protein_map") . }}'><kbd class="bg-primary">{{ . }}</kbd></a>
   {{ end }}


### PR DESCRIPTION
## Description
This is a first pass at cleaning up the appearance of the entries on the site. It makes the styling of all the entries uniform across the site:
* h4 for name of entry
* h5 for fields in the entry
* bold field names for clarity
* Condense small lists to inline
* Have long lists on multi-line.

This has a side effect of compacting many of the entries into a smaller area, allowing for more entries to be viewed at once.

## Status
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


