### PR TITLE
External links: moved biology to top and fixed anchors

### DIFF
--- a/themes/minimal/layouts/links/single.html
+++ b/themes/minimal/layouts/links/single.html
@@ -13,7 +13,7 @@
         <h5 align="left">
         Data classification:
             <ul style="text-align:justify;">
-                {{ range slice "structures" "models" "therapeutics"}}
+                {{ range slice "biology" "structures" "models" "therapeutics"}}
                     {{ $data := index $.Site.Data.glossary . }}
                     <li><a href="{{ delimit (slice "#ext" "res" (string $data.term) ) "_" }}"><b>{{ $data.term | title }}:</b></a> {{ $data.short }}</li>
                 {{ end }}
@@ -21,6 +21,14 @@
             </ul>
         </h5>
         <hr class="hr-thick">
+
+        <h3 class="anchor" id="ext_res_Biology"> Biology </h3>
+        {{ range $.Site.Data.links  }}
+            {{ if in .resources "biology" }}
+                {{ partial "links-data.html" (dict "links" . "context" $) }}
+            {{ end }}
+        {{ end }}
+
         {{ $localScratch.Set "struct" slice }}
         {{ range $.Site.Data.links }}
             {{ if eq .resources "structures" }}
@@ -29,39 +37,33 @@
         {{ end }}
         {{ $structs := $localScratch.Get "struct" }}
         {{ if $structs }}
-            <h3 id="ext_res_Structures" > Structures </h3>
+            <h3 class="anchor" id="ext_res_Structures" > Structures </h3>
             {{ range $structs }}
                 {{ partial "links-data.html" (dict "links" . "context" $) }}
             {{ end }}
         {{ end }}
 
-        <h3 id="ext_res_Models"> Models </h3>
+        <h3 class="anchor" id="ext_res_Models"> Models </h3>
         {{ range $.Site.Data.links  }}
             {{ if in .resources "models" }}
                 {{ partial "links-data.html" (dict "links" . "context" $) }}
             {{ end }}
         {{ end }}
 
-        <h3 id="ext_res_Therapeutics"> Therapeutics and Drug Databases </h3>
+        <h3 class="anchor" id="ext_res_Therapeutics"> Therapeutics and Drug Databases </h3>
         {{ range $.Site.Data.links  }}
             {{ if in .resources "therapeutics" }}
                 {{ partial "links-data.html" (dict "links" . "context" $) }}
             {{ end }}
         {{ end }}
-        
-        <h3 id="ext_res_Publications"> Publications </h3>
+
+        <h3 class="anchor" id="ext_res_Publications"> Publications </h3>
         {{ range $.Site.Data.links  }}
             {{ if in .resources "publications" }}
                 {{ partial "links-data.html" (dict "links" . "context" $) }}
             {{ end }}
         {{ end }}
 
-        <h3 id="ext_res_Biology"> Biology </h3>
-        {{ range $.Site.Data.links  }}
-            {{ if in .resources "biology" }}
-                {{ partial "links-data.html" (dict "links" . "context" $) }}
-            {{ end }}
-        {{ end }}
 
     </div>
 </main>


### PR DESCRIPTION
* Moved the Biology category to the top of the page in the links page
* Made the anchor jumps work correctly with the header in links
* Added the glossary term for biology to the top of the links

## Status
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


