### PR TITLE
Add google analytics to the site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@ languageCode = "en-us"
 title = "COVID-19 Molecular Structure and Therapeutics Hub"
 theme = "minimal"
 # disqusShortname = "username" # delete this to disable disqus comments
-# googleAnalytics = ""
+googleAnalytics = "UA-166331808-1"
 
 # Additional custom parameters
 # Ignore README files meant for GitHub


### PR DESCRIPTION
## Description
This add the Google Analytics hook for the static site. We expect about 40% under-reporting from previous sites due to ad blocks, but at least this will give us an idea.

The GeoIP2 stuff will come after we get the flask site up for a future enhancement.


## Status
- [x Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


