### PR TITLE
Make Voth Group singular contributor per request

### DIFF
--- a/data/contributors/people.yml
+++ b/data/contributors/people.yml
@@ -138,12 +138,6 @@ members:
   - name: Chengxin Zhang
     url: https://zhanglab.ccmb.med.umich.edu/
     organization: zhang-lab
-  - name: Gregory A. Voth
-    url: https://vothgroup.uchicago.edu/greg-voth
-    organization: voth-group
-  - name: Alex Pak
-    url: https://vothgroup.uchicago.edu/group/voth-group-members/alex-pak
-    organization: voth-group
-  - name: Alvin Yu
-    url: https://vothgroup.uchicago.edu/group/voth-group-members/alvin-yu
+  - name: Voth Group
+    url: https://vothgroup.uchicago.edu
     organization: voth-group


### PR DESCRIPTION
## Description
I received a change the contributors a bit to merge all Voth group members into one. Doing so here.


## Status
- [x] YAML file for each piece of data
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


