### PR TITLE
add Solvation Map external link

### DIFF
--- a/data/links/covid_solvation_Map.yml
+++ b/data/links/covid_solvation_Map.yml
@@ -1,6 +1,6 @@
 name: Solvation Maps for COVID19-related Protein Targets
 url: https://github.com/KurtzmanLab/COVID19_GIST_HSA
-description: >This is a free online repository for sharing GIST/HSA data of COVID19 related protein targets. Currently, we have the GIST/HSA data for 7 targets: 6LU7, 6YB7, 6M03, 6Y84, 6W63, 6JYT and 6W4H.
+description: This is a free online repository for sharing GIST/HSA data of COVID19 related protein targets. Currently, we have the GIST/HSA data for 7 targets: 6LU7, 6YB7, 6M03, 6Y84, 6W63, 6JYT and 6W4H.
 lab: Tom Kurtzman
 institution: Lehman College, City University of New York
 resources:

--- a/data/links/covid_solvation_Map.yml
+++ b/data/links/covid_solvation_Map.yml
@@ -1,6 +1,6 @@
 name: Solvation Maps for COVID19-related Protein Targets
 url: https://github.com/KurtzmanLab/COVID19_GIST_HSA
-description: This is a free online repository for sharing GIST/HSA data of COVID19 related protein targets. Currently, we have the GIST/HSA data for 7 targets: 6LU7, 6YB7, 6M03, 6Y84, 6W63, 6JYT and 6W4H.
+description: This is a free online repository for sharing GIST/HSA data of COVID19 related protein targets. Currently, we have th3 GIST/HSA data for 7 targets (6LU7, 6YB7, 6M03, 6Y84, 6W63, 6JYT and 6W4H).
 lab: Tom Kurtzman
 institution: Lehman College, City University of New York
 resources:

--- a/data/links/covid_solvation_Map.yml
+++ b/data/links/covid_solvation_Map.yml
@@ -1,0 +1,7 @@
+name: Solvation Maps for COVID19-related Protein Targets
+url: https://github.com/KurtzmanLab/COVID19_GIST_HSA
+description: >This is a free online repository for sharing GIST/HSA data of COVID19 related protein targets. Currently, we have the GIST/HSA data for 7 targets:Structures 1-5 (SARS-CoV-2 structures) Main Protease (Mpro, 3CLpro): 6LU7 (2.16 Å), 6YB7 (1.25 Å), 6M03 (2.00 Å), 6Y84 (1.39 Å), 6W63 (2.10 Å). Target the substrate binding site of Mpro.Structure 6 (SARS-CoV-1 structure) Helicase (Nsp13): 6JYT (2.80 Å). Target (1) the ADP binding site but discourage (2) the nucleic acids binding site.Structure 7 (SARS-CoV-2 structure) Nsp16 (2’-O-methyltransferase, nsp 10/16): 6W4H (1.80 Å). Target: S-adenosylmethionine (SAM) binding site.
+lab: Tom Kurtzman
+institution: Lehman College, City University of New York
+resources:
+  - models

--- a/data/links/covid_solvation_Map.yml
+++ b/data/links/covid_solvation_Map.yml
@@ -1,6 +1,6 @@
 name: Solvation Maps for COVID19-related Protein Targets
 url: https://github.com/KurtzmanLab/COVID19_GIST_HSA
-description: >This is a free online repository for sharing GIST/HSA data of COVID19 related protein targets. Currently, we have the GIST/HSA data for 7 targets:Structures 1-5 (SARS-CoV-2 structures) Main Protease (Mpro, 3CLpro): 6LU7 (2.16 Å), 6YB7 (1.25 Å), 6M03 (2.00 Å), 6Y84 (1.39 Å), 6W63 (2.10 Å). Target the substrate binding site of Mpro.Structure 6 (SARS-CoV-1 structure) Helicase (Nsp13): 6JYT (2.80 Å). Target (1) the ADP binding site but discourage (2) the nucleic acids binding site.Structure 7 (SARS-CoV-2 structure) Nsp16 (2’-O-methyltransferase, nsp 10/16): 6W4H (1.80 Å). Target: S-adenosylmethionine (SAM) binding site.
+description: >This is a free online repository for sharing GIST/HSA data of COVID19 related protein targets. Currently, we have the GIST/HSA data for 7 targets: 6LU7, 6YB7, 6M03, 6Y84, 6W63, 6JYT and 6W4H.
 lab: Tom Kurtzman
 institution: Lehman College, City University of New York
 resources:


### PR DESCRIPTION
## Description

A Github repository including thermodynamic solvation maps for 7 COVID19-related protein structures. The solvation maps are potentially useful for lead optimization/docking for those targets.


## Status
- [ ] YAML file for each piece of data
- [ ] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


