### PR TITLE
JYU models and simulation trajectories for RdRp complexes 

### DIFF
--- a/data/models/RdRp-RNA-ATP-complex.yml
+++ b/data/models/RdRp-RNA-ATP-complex.yml
@@ -1,0 +1,25 @@
+﻿name: "SARS-CoV-2 RdRp complex (nsp12+2*nsp8+nsp7) + RNA template-primer + ATP  model for MD simulations"
+description: Model of the RdRp + RNA + ATP complex of the SARS-CoV-2 with non-covalently bound ATP molecule is built using homology
+  modelling with the SARS-CoV-1 RdRp complex (PDB:6NUR) as template structure (https://doi.org/10.1038/s41467-019-10280-3). The 
+  modelled structure shows excellent fit (< 0.6 Å) to the SARS-CoV-2 RdRp complex (PDB:6M71) kindly shared with us by Gao et.al.
+  Further, the model of RdRp complex with RNA and ATP molecule in Tri-phosphate form is modelled based on comparative
+  fitting with previously known poliovirus and norovirus structres (with NTP molecule in hydrophobic cleft). The protein-RNA
+  complex with Remdesivir shows excellent fit (< 0.7 Å) with the recently published RdRp complex with RNA template-primer 
+  (PDB:7BV2, 6YYT). The fitted models have been equilibriated to perform long MD simulations.  
+url: https://github.com/bioexcel/covid_modelling_simulation_data/blob/master/rdrp_polymerase/
+pdb_url: https://github.com/bioexcel/covid_modelling_simulation_data/blob/master/rdrp_polymerase/RdRp-RNA-ATP-complex/RdRp-RNA-ATP-complex.pdb
+pdbids: 
+pdbids: 
+  - 6NUR
+  - 7BTF
+  - 7BV2
+  - 6YYT
+proteins: 
+  - RdRP 
+  - NSP12
+  - NSP7
+  - NSP8
+creator: Vaibhav Modi
+organization: University of Jyväskylä
+institution: Department of Chemistry and Nanoscience Center
+lab: Computational Biomolecular Chemistry Group

--- a/data/models/RdRp-RNA-RTP-complex.yml
+++ b/data/models/RdRp-RNA-RTP-complex.yml
@@ -1,0 +1,25 @@
+﻿name: "SARS-CoV-2 RdRp complex (nsp12+2*nsp8+nsp7) + RNA template-primer + RTP (Remdesivir Tri-phosphate) model for MD simulations"
+description: Model of the RdRp + RNA + NTP complex of the SARS-CoV-2 with non-covalently bound NTP molecule is built using homology
+  modelling with the SARS-CoV-1 RdRp complex (PDB:6NUR) as template structure (https://doi.org/10.1038/s41467-019-10280-3). The 
+  modelled structure shows excellent fit (< 0.6 Å) to the SARS-CoV-2 RdRp complex (PDB:6M71) kindly shared with us by Gao et.al.
+  Further, the model of RdRp complex with RNA and Remdesivir molecule in Tri-phosphate form is modelled based on comparative
+  fitting with previously known poliovirus and norovirus structres (with NTP molecule in hydrophobic cleft). The protein-RNA
+  complex with Remdesivir shows excellent fit (< 0.5 Å) with the recently published RdRp complex with RNA template-primer and 
+  covalently bound Remdesivir in mono-phosphate form (PDB:7BV2, 6YYT) The fitted models have been equilibriated to perform long MD 
+  simulations.  
+url: https://github.com/bioexcel/covid_modelling_simulation_data/blob/master/rdrp_polymerase/
+pdb_url: https://github.com/bioexcel/covid_modelling_simulation_data/blob/master/rdrp_polymerase/RdRp-RNA-RTP-complex/RdRp-RNA-RTP-complex.pdb
+pdbids: 
+  - 6NUR
+  - 6M71
+  - 7BV2
+proteins: 
+  - RdRP 
+  - NSP12
+  - NSP7
+  - NSP8
+creator: Vaibhav Modi
+organization: University of Jyväskylä
+institution: Department of Chemistry and Nanoscience Center
+lab: Computational Biomolecular Chemistry Group
+

--- a/data/models/apo-RdRp-complex.yml
+++ b/data/models/apo-RdRp-complex.yml
@@ -1,0 +1,21 @@
+﻿name: "SARS-CoV-2 apo-RdRp complex (nsp12+2*nsp8+nsp7) model for MD simulations"
+description: Model of the apo-protein form of RdRp complex of the SARS-CoV-2 is built using homology modelling with the 
+  SARS-CoV-1 RdRp complex (PDB:6NUR) as template structure (https://doi.org/10.1038/s41467-019-10280-3). The modelled structure
+  shows excellent fit (< 0.6 Å) to the SARS-CoV-2 RdRp complex (PDB:6M71,7BV1) kindly shared with us by Gao et.al.
+  The fitted models have been equilibriated to perform long MD simulations.  
+url: https://github.com/bioexcel/covid_modelling_simulation_data/blob/master/rdrp_polymerase/
+pdb_url: https://github.com/bioexcel/covid_modelling_simulation_data/blob/master/rdrp_polymerase/apo-RdRp/apo-RdRp.pdb
+pdbids:
+  - 6NUR
+  - 6M71
+  - 7BTF
+  - 7BV1
+proteins: 
+  - RdRP 
+  - NSP12
+  - NSP7
+  - NSP8
+creator: Vaibhav Modi
+organization: University of Jyväskylä
+institution: Department of Chemistry and Nanoscience Center
+lab: Computational Biomolecular Chemistry Group

--- a/data/proteins/nsp12.yml
+++ b/data/proteins/nsp12.yml
@@ -1,0 +1,5 @@
+protein: NSP12
+name: Coronavirus nonstructural protein 12
+description: Suppressor of host genome expression
+organism: SARS-CoV-2
+domain: nsp

--- a/data/simulations/RdRp_RNA_ATP_100ns_allatom.yml
+++ b/data/simulations/RdRp_RNA_ATP_100ns_allatom.yml
@@ -1,0 +1,40 @@
+﻿type: md
+title: Gromacs 100 ns MD of SARS-CoV-2 RdRp + RNA template-primer + ATP model, All Atom model
+description: >
+  This trajectory is from a 100 ns atomic MD simulation of the SARS-CoV-2 RdRp-RNA-ATP-complex protein. The protein was solvated in a 
+  16 x 16 x 16 nm box of solvent containing water and 0.15 M NaCl. The simulation was performed with Gromacs 2018.8 
+  on the Puhti cluster located at the CSC-IT using the Amber14sb-OL15 force field. The interval
+  between frames is 100 ps. The simulation was conducted in the NPT ensemble (1 bar and 300K).
+creator: Vaibhav Modi
+organization: University of Jyväskylä
+institute: Department of Chemistry and Nanoscience Center
+models:
+  - RdRp-RNA-ATP-complex
+proteins: 
+  - RdRP 
+  - NSP12
+  - NSP7
+  - NSP8
+structures:
+  - 6NUR
+  - 6M71
+  - 7BTF
+  - 7BV2
+  - 6YYT
+ensemble: NPT
+forcefields:
+  - Amber14sb-OL15
+files: 
+  - https://github.com/bioexcel/covid_modelling_simulation_data/tree/master/rdrp_polymerase/RdRp-RNA-ATP-complex
+  - https://github.com/bioexcel/covid_modelling_simulation_data/tree/master/rdrp_polymerase/amber14sb_OL15.ff
+trajectory: https://a3s.fi/swift/v1/AUTH_9dc2202df4e44114a3949af1f7bbde96/RdRp-complex/RdRp-RNA-ATP-complex/traj_RdRp-RNA-ATP-complex.xtc
+size: 1.5 GB
+solvent: Water
+temperature: 300
+pressure: 0.987
+salinity: 0.15
+length: 100 ns
+references:
+  - "Mark James Abraham, Teemu Murtola, Roland Schulz, Szilard Pall, Jeremy C. Smith, Berk Hess, Erik Lindahl,
+     GROMACS: High performance molecular simulations through multi-level parallelism from laptops to supercomputers,
+     SoftwareX, 2015, V. 1-2, pp. 19-25"

--- a/data/simulations/RdRp_RNA_RTP_100ns_allatom.yml
+++ b/data/simulations/RdRp_RNA_RTP_100ns_allatom.yml
@@ -1,0 +1,39 @@
+﻿type: md
+title: Gromacs 100 ns MD of SARS-CoV-2 RdRp + RNA template-primer + RTP (Remdesivir Tri-Phosphate) model, All Atom model
+description: >
+  This trajectory is from a 100 ns atomic MD simulation of the SARS-CoV-2 RdRp-RNA-RTP-complex protein. The protein was solvated in a 
+  16 x 16 x 16 nm box of solvent containing water and 0.15 M NaCl. The simulation was performed with Gromacs 2018.8 
+  on the Puhti cluster located at the CSC-IT using the Amber14sb-OL15 force field. The interval
+  between frames is 100 ps. The simulation was conducted in the NPT ensemble (1 bar and 300K).
+creator: Vaibhav Modi
+organization: University of Jyväskylä
+institute: Department of Chemistry and Nanoscience Center
+models:
+  - RdRp-RNA-RTP-complex
+proteins: 
+  - RdRP 
+  - NSP12
+  - NSP7
+  - NSP8
+structures:
+  - 6M71
+  - 7BTF
+  - 7BV2
+  - 6YYT
+ensemble: NPT
+forcefields:
+  - Amber14sb-OL15
+files: 
+  - https://github.com/bioexcel/covid_modelling_simulation_data/tree/master/rdrp_polymerase/RdRp-RNA-RTP-complex
+  - https://github.com/bioexcel/covid_modelling_simulation_data/tree/master/rdrp_polymerase/amber14sb_OL15.ff
+trajectory: https://a3s.fi/swift/v1/AUTH_9dc2202df4e44114a3949af1f7bbde96/RdRp-complex/RdRp-RNA-RTP-complex/traj_RdRp-RNA-RTP-complex.xtc
+size: 1.5 GB
+solvent: Water
+temperature: 300
+pressure: 0.987
+salinity: 0.15
+length: 100 ns
+references:
+  - "Mark James Abraham, Teemu Murtola, Roland Schulz, Szilard Pall, Jeremy C. Smith, Berk Hess, Erik Lindahl,
+     GROMACS: High performance molecular simulations through multi-level parallelism from laptops to supercomputers,
+     SoftwareX, 2015, V. 1-2, pp. 19-25"

--- a/data/simulations/apo_RdRp_300ns_allatom.yml
+++ b/data/simulations/apo_RdRp_300ns_allatom.yml
@@ -1,0 +1,38 @@
+﻿type: md
+title: Gromacs 300 ns MD of SARS-CoV-2 apo-RdRp model, All Atom model
+description: >
+  This trajectory is from a 300 ns atomic MD simulation of the SARS-CoV-2 RdRp apo-protein model. The protein was solvated in a 
+  16 x 16 x 16 nm box of solvent containing water and 0.15 M NaCl. The simulation was performed with Gromacs 2018.8 
+  on the Puhti cluster located at the CSC-IT using the Amber14sb-OL15 force field. The interval
+  between frames is 400 ps. The simulation was conducted in the NPT ensemble (1 bar and 300K).
+creator: Vaibhav Modi
+organization: University of Jyväskylä
+institute: Department of Chemistry and Nanoscience Center
+models:
+  - apo-RdRp-complex 
+proteins: 
+  - RdRP 
+  - NSP12
+  - NSP7
+  - NSP8
+structures:
+  - 6M71
+  - 7BTF
+  - 7BV1
+ensemble: NPT
+forcefields:
+  - Amber14sb-OL15
+files: 
+  - https://github.com/bioexcel/covid_modelling_simulation_data/tree/master/rdrp_polymerase/apo-RdRp
+  - https://github.com/bioexcel/covid_modelling_simulation_data/tree/master/rdrp_polymerase/amber14sb_OL15.ff
+trajectory: https://a3s.fi/swift/v1/AUTH_9dc2202df4e44114a3949af1f7bbde96/RdRp-complex/apo-RdRp/traj_apo-RdRp.xtc
+size: 1.2 GB
+solvent: Water
+temperature: 300
+pressure: 0.987
+salinity: 0.15
+length: 300 ns
+references:
+  - "Mark James Abraham, Teemu Murtola, Roland Schulz, Szilard Pall, Jeremy C. Smith, Berk Hess, Erik Lindahl,
+     GROMACS: High performance molecular simulations through multi-level parallelism from laptops to supercomputers,
+     SoftwareX, 2015, V. 1-2, pp. 19-25"

--- a/schema/validation.py
+++ b/schema/validation.py
@@ -21,6 +21,7 @@ class ValidProteins(str, Enum):
     NSP9 = 'NSP9'
     NSP10 = 'NSP10'
     NSP11 = 'NSP11'
+    NSP12 = 'NSP12'
     Helicase = 'Helicase'
     NSP14 = 'NSP14'
     NSP15 = 'NSP15'


### PR DESCRIPTION
Added JYU models and simulation trajectories for RdRp complexes native ATP substrate and RTP (Remdesivir Triphosphate) 

Also added NSP12 protein, check PDB:6M71 for more details

## Description
Provide a brief description of the data being added here.


## Status
- [ ] YAML file for each piece of data
- [ ] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


