### PR TITLE
Validation script tries and catch common protein names

### DIFF
--- a/data/models/RdRp-RNA-ATP-complex.yml
+++ b/data/models/RdRp-RNA-ATP-complex.yml
@@ -9,14 +9,12 @@ description: Model of the RdRp + RNA + ATP complex of the SARS-CoV-2 with non-co
 url: https://github.com/bioexcel/covid_modelling_simulation_data/blob/master/rdrp_polymerase/
 pdb_url: https://github.com/bioexcel/covid_modelling_simulation_data/blob/master/rdrp_polymerase/RdRp-RNA-ATP-complex/RdRp-RNA-ATP-complex.pdb
 pdbids: 
-pdbids: 
   - 6NUR
   - 7BTF
   - 7BV2
   - 6YYT
 proteins: 
-  - RdRP 
-  - NSP12
+  - RdRP
   - NSP7
   - NSP8
 creator: Vaibhav Modi

--- a/data/models/RdRp-RNA-RTP-complex.yml
+++ b/data/models/RdRp-RNA-RTP-complex.yml
@@ -14,8 +14,7 @@ pdbids:
   - 6M71
   - 7BV2
 proteins: 
-  - RdRP 
-  - NSP12
+  - RdRP
   - NSP7
   - NSP8
 creator: Vaibhav Modi

--- a/data/models/apo-RdRp-complex.yml
+++ b/data/models/apo-RdRp-complex.yml
@@ -11,8 +11,7 @@ pdbids:
   - 7BTF
   - 7BV1
 proteins: 
-  - RdRP 
-  - NSP12
+  - RdRP
   - NSP7
   - NSP8
 creator: Vaibhav Modi

--- a/data/proteins/nsp12.yml
+++ b/data/proteins/nsp12.yml
@@ -1,5 +1,0 @@
-protein: NSP12
-name: Coronavirus nonstructural protein 12
-description: Suppressor of host genome expression
-organism: SARS-CoV-2
-domain: nsp

--- a/data/simulations/RdRp_RNA_ATP_100ns_allatom.yml
+++ b/data/simulations/RdRp_RNA_ATP_100ns_allatom.yml
@@ -11,8 +11,7 @@ institute: Department of Chemistry and Nanoscience Center
 models:
   - RdRp-RNA-ATP-complex
 proteins: 
-  - RdRP 
-  - NSP12
+  - RdRP
   - NSP7
   - NSP8
 structures:

--- a/data/simulations/RdRp_RNA_RTP_100ns_allatom.yml
+++ b/data/simulations/RdRp_RNA_RTP_100ns_allatom.yml
@@ -11,8 +11,7 @@ institute: Department of Chemistry and Nanoscience Center
 models:
   - RdRp-RNA-RTP-complex
 proteins: 
-  - RdRP 
-  - NSP12
+  - RdRP
   - NSP7
   - NSP8
 structures:

--- a/data/simulations/apo_RdRp_300ns_allatom.yml
+++ b/data/simulations/apo_RdRp_300ns_allatom.yml
@@ -11,8 +11,7 @@ institute: Department of Chemistry and Nanoscience Center
 models:
   - apo-RdRp-complex 
 proteins: 
-  - RdRP 
-  - NSP12
+  - RdRP
   - NSP7
   - NSP8
 structures:

--- a/data/structures/README.md
+++ b/data/structures/README.md
@@ -29,7 +29,7 @@ proteins: (one or more of the following options)
   - NSP9
   - NSP10
   - NSP11
-  - NSP12
+  - RdRP
   - Helicase
   - NSP14
   - NSP15
@@ -39,7 +39,6 @@ proteins: (one or more of the following options)
   - TMPRSS2
   - 3CLpro
   - PLpro
-  - RdRP
   - ORF3a
   - ORF6
   - ORF8

--- a/schema/validation.py
+++ b/schema/validation.py
@@ -39,7 +39,7 @@ class ValidProteins(str, Enum):
     NSP9 = 'NSP9'
     NSP10 = 'NSP10'
     NSP11 = 'NSP11'
-    NSP12 = 'NSP12'
+    RdRP = 'RdRP'
     Helicase = 'Helicase'
     NSP14 = 'NSP14'
     NSP15 = 'NSP15'
@@ -50,7 +50,6 @@ class ValidProteins(str, Enum):
     TMPRSS2 = 'TMPRSS2'
     Mpro = '3CLpro'
     PLpro = 'PLpro'
-    RdRP = 'RdRP'
     BoAT1 = 'BoAT1'
     FcR = 'Fc receptor'
     Furin = 'Furin'
@@ -67,6 +66,36 @@ class ValidProteins(str, Enum):
     E_protein = 'E protein'
     PD_1 = 'PD-1'
     virion = "virion"
+
+
+# Check that proteins have not been given other names
+common_names = {
+    '3CLpro': ['mpro', 'nsp5', '3c-like', '3c-l', 'mprotease', '3cl-pro'],
+    'PLpro': ['nsp3', 'p-l', 'papin', 'papin-like', 'pl-pro'],
+    'E protein': ['e-protein', 'envelope', 'e-pro', 'epro', 'orf4'],
+    'Helicase': ['hel', 'nsp13'],
+    'M protein': ['membrane', 'mem', 'm-protein', 'm-pro', 'orf5'],
+    'N protein': ['nucleoprotein', 'nucleocapsid', 'nuc', 'orf9'],
+    'RdRP': ['nsp12', 'rna prot', 'rna', 'rna-prot', 'rna-dir']
+    }
+# make a reverse map.
+alt_names = {}
+for common, alts in common_names.items():
+    for alt in alts:
+        alt_names[alt] = common
+# Check for overlap
+overlap_map = []
+for prot in ValidProteins:
+    value = prot.value  # IDE's complain, its a valid property for Enum objects.
+    if value.lower() in alt_names:
+        overlap_map.append([value, alt_names[value.lower()]])
+if overlap_map:
+    err_string = "A protein was defined in the ValidProtein's schema, but already has a more common name. Please " \
+                 "changing the following item(s) to its/their more common name(s):\n"
+    for value, common in overlap_map:
+        err_string += f"\t{value} -> {common}\n"
+    err_string += "If you think this is in error, please raise the issue on GitHub"
+    raise ValueError(err_string)
 
 
 class ValidDomains(str, Enum):


### PR DESCRIPTION
## Description
Adds some logic to the validation script which tries to trap any
addition of proteins which have a more common name (e.g. NSP3 = PLpro).
Its not crude, but its at least a basic check.

Also changed some entries which pointed to NSP12 instead of RdRP

## Status
- [x] YAML file for each piece of data
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


