### PR TITLE
Doi anchor

### DIFF
--- a/data/dois/README.md
+++ b/data/dois/README.md
@@ -17,6 +17,7 @@ creator: (required)
 content: (required)
 purpose: (required)
 file_types: (required)
+files: (required)
 size: (required)
 license: (optional)
 ```

--- a/data/dois/isayev.yml
+++ b/data/dois/isayev.yml
@@ -15,6 +15,8 @@ owner: Olexandr Isayev
 creator: Olexandr Isayev
 file_types:
   - sdf
+files:
+  - https://covmme.molssi.org/data/isayev/drug_dbs/fda-drugs-ani2x_v1.zip
 purpose: Data for tautomers And conformers Of 6,433 FDA approved investigational drugs published in 2020
 size: 2.1 GB
 license: CC BY-NC-ND 4.0

--- a/data/dois/isayev2.yml
+++ b/data/dois/isayev2.yml
@@ -16,6 +16,8 @@ creator: Olexandr Isayev
 owner: Olexandr Isayev
 file_types:
   - sdf
+files:
+  - https://covmme.molssi.org/data/isayev/drug_dbs/cas-antiviral-ani2x_v1.zip
 purpose: Data for automers and conformers from the CAS antiviral database published in 2020
 size: 5.3 GB
 license: CC BY-NC-ND 4.0

--- a/data/dois/voth.yml
+++ b/data/dois/voth.yml
@@ -9,5 +9,7 @@ creator: Alvin Yu & Gregory Voth
 owner: Alvin Yu & Gregory Voth
 file_types:
   - pdb
+files:
+  - https://github.com/alvinyu33/sars-cov-2-public/blob/9b46373cb878929de5b74804a37f20fa73efa48e/sars-cov-2-virion-cg.pdb
 purpose: Coarse-grained structural data for the SARS-CoV-2 virion
 size: 17.3 MB

--- a/data/dois/voth2.yml
+++ b/data/dois/voth2.yml
@@ -9,5 +9,7 @@ creator: Alvin Yu & Gregory Voth
 owner: Alvin Yu & Gregory Voth
 file_types:
   - pdb
+files:
+  - https://github.com/alvinyu33/sars-cov-2-public/tree/9b46373cb878929de5b74804a37f20fa73efa48e
 purpose: Coarse-grained data for multiscale models of the SARS-CoV-2 virion
 size: 6.2 MB

--- a/schema/validation.py
+++ b/schema/validation.py
@@ -178,6 +178,7 @@ class DOIModel(BaseModel):
     owner: str
     content: List[str]
     file_types: List[str]
+    files: List[str]
     size: str
     purpose: str
     license: Optional[str]

--- a/themes/minimal/layouts/dois/single.html
+++ b/themes/minimal/layouts/dois/single.html
@@ -10,8 +10,8 @@
 
         <hr class="hr-thick">
                 
-        {{ range $.Site.Data.dois  }}
-            {{ partial "dois-data.html" (dict "dois" . "context" $) }}
+        {{ range $filename, $yamlcontent := $.Site.Data.dois  }}
+            {{ partial "dois-data.html" (dict "dois" $yamlcontent "context" . "filename" $filename) }}
         {{ end }}
     </div>
 </main>

--- a/themes/minimal/layouts/partials/dois-data.html
+++ b/themes/minimal/layouts/partials/dois-data.html
@@ -1,6 +1,6 @@
 {{ $localScratch := newScratch }}
 
-<a href="https://covid.molssi.org/dois/dois/#{{.filename}}"><h4 align="center">{{ .dois.name | title }}</h4></a>
+<a href="https://covid.molssi.org/dois/#{{.filename}}"><h4 align="center">{{ .dois.name | title }}</h4></a>
 
 <p align="justify"><b>DOI:</b> <a href = "https://doi.org/{{ .dois.doi }}"> {{ .dois.doi | markdownify }} </a></p>
 <p align="justify"><b>Description:</b> {{ .dois.description | markdownify }}</p>

--- a/themes/minimal/layouts/partials/dois-data.html
+++ b/themes/minimal/layouts/partials/dois-data.html
@@ -1,7 +1,6 @@
-
 {{ $localScratch := newScratch }}
 
-<a href="{{.dois.url}}"><h4 align="center">{{ .dois.name | title }}</h4></a>
+<a href="https://covid.molssi.org/dois/dois/#{{.filename}}"><h4 align="center">{{ .dois.name | title }}</h4></a>
 
 <p align="justify"><b>DOI:</b> <a href = "https://doi.org/{{ .dois.doi }}"> {{ .dois.doi | markdownify }} </a></p>
 <p align="justify"><b>Description:</b> {{ .dois.description | markdownify }}</p>
@@ -20,6 +19,16 @@
 <p align="justify"><b>File types:</b>
 {{ range .dois.file_types }}
      <kbd class="alert-primary"> {{ . | markdownify }} </kbd>
+{{ end }}
+</p>
+
+<p align="justify"><b>Files:</b>
+{{ if .dois.files }}
+    {{ range (seq (len .dois.files)) }}
+        <a href="{{ index $.dois.files (sub . 1) }}"><kbd class="alert-secondary">[.]</kbd></a>
+    {{ end }}
+{{ else }}
+    ---
 {{ end }}
 </p>
 


### PR DESCRIPTION
## Description
This adds anchors to the DOI entries based on their yml files. This is in preparation of directing DOIs to the specific entries on the page. Added a `Files` field for each entry to contain download links to the files.


## Status
- [ ] YAML file for each piece of data
- [ ] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


