### PR TITLE
Folding@home Mpro monomer simulations

### DIFF
--- a/data/models/FAH-Mpro-monomer.yml
+++ b/data/models/FAH-Mpro-monomer.yml
@@ -1,0 +1,18 @@
+name: SARS-CoV-2 main protease (apo, monomer) for Folding@home simulations
+description: > 
+  Apo, monomeric Mpro/3CLpro from PDB structure `6lu7` used in Folding@home simulations. 
+  Chain A (i.e. a monomer of the protein, without the inhibitor or waters) was extracted from `6lu7` using PyMOL, and protonated and capped (ACE, NME) with Schrodinger's Maestro.
+  The protein was solvated in a cubic box with 1 nm padding and 150 mM NaCl using OpenMM 7.4.1.
+url: https://github.com/FoldingAtHome/coronavirus/tree/master/system-preparation/6lu7_receptor/output
+pdb_url: https://github.com/FoldingAtHome/coronavirus/blob/master/system-preparation/6lu7_receptor/output/solvated.pdb
+pdbids:
+  - 6LU7
+proteins:
+  - 3CLpro
+creator: Ivy Zhang, Hannah Bruce Macdonald
+organization: Folding@home
+institution: Memorial Sloan Kettering Cancer Center
+lab: Chodera lab
+rating:
+publication:
+preprint:

--- a/data/simulations/FAH-Mpro-monomer-no-water.yml
+++ b/data/simulations/FAH-Mpro-monomer-no-water.yml
@@ -3,7 +3,7 @@ title: SARS-CoV-2 main protease (apo, monomer) Folding@home simulations
 description: >
   This is a dataset containing 5688 trajectories at least 250 ns in length (2.6 ms in total) of SARS-CoV-2 main viral protease (Mpro/3CLpro) in its apo, monomeric form. 
   Water (but not salt) has been stripped from the trajectories, frames are saved every 0.2 ns.
-  Simulations were initiated from PDB structure `6lu7`, chain A, after removing the inhibitor and structural waters.
+  Simulations were initiated from PDB structure [6lu7](http://www.rcsb.org/structure/6LU7), chain A, after removing the inhibitor and structural waters.
   
   The dataset is organized by Folding@home project number (11743 and 11749) due to the F@h parallelization -- there are no differences in setups between the projects 
   and there is no relation between the identically named files - all trajectories (`CLONE`s) are initialized with random velocities.

--- a/data/simulations/FAH-Mpro-monomer-no-water.yml
+++ b/data/simulations/FAH-Mpro-monomer-no-water.yml
@@ -14,23 +14,23 @@ description: >
   then for 1.25 ns using 4 fs timestep with OpenMMTools custom Langevin integrator using `V R O R V` splitting.
   All Folding@home trajectories were then seeded with random velocities from this system.
 
-  The dataset is available through AWS Public Datasets as explained below, as well as Open Science Framework at https://osf.io/d9tm2
-  
-  The AWS dataset can be accessed through the command line interface (CLI) as follows:  
+  The dataset is available through AWS Public Datasets and can be accessed through the command line interface (CLI) as follows:  
+    
     1) Install the AWS CLI:  
-      `conda install awscli`  
+      `conda install -c conda-forge awscli`  
       or  
       `pip install awscli`  
     2) Configure the CLI with your AWS account: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html  
     3) To download the whole dataset (519 GB):  
       `aws s3 sync s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`  
     4) To download subsets of the dataset appropriate query terms can be used, e.g.:  
-       the first trajectory of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone0.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`
-       the first 10 trajectories of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone?.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`
-       the first 100 trajectories of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone??.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`
+       the first trajectory of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone0.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`  
+       the first 10 trajectories of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone?.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`  
+       the first 100 trajectories of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone??.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`  
 
-  Note that an AWS account is required to use the CLI. Individual files can also be downloaded without an AWS account as follows: https://fah-public-data-covid19-moonshot-dynamics.s3.us-east-2.amazonaws.com/SARS-CoV-2_main_protease_monomer/11743/run0-clone0.h5
-  Data can also be browsed and downloaded in the AWS Management Console at https://s3.console.aws.amazon.com/s3/buckets/fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer
+  Note that an AWS account is required to use the CLI. Individual files can also be downloaded without an AWS account, for example: https://fah-public-data-covid19-moonshot-dynamics.s3.us-east-2.amazonaws.com/SARS-CoV-2_main_protease_monomer/11743/run0-clone0.h5  
+  Data can also be browsed and downloaded in the AWS Management Console at https://s3.console.aws.amazon.com/s3/buckets/fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer  
+  Alternatively, the dataset is also available through the Open Science Framework at https://osf.io/d9tm2
 creator: Rafal Wiewiora, John Chodera
 organization: Folding@home
 lab: Chodera lab

--- a/data/simulations/FAH-Mpro-monomer-no-water.yml
+++ b/data/simulations/FAH-Mpro-monomer-no-water.yml
@@ -17,22 +17,22 @@ description: >
   The dataset is available through AWS Public Datasets and can be accessed through the command line interface (CLI) as follows:  
     
     1) Install the [AWS CLI](https://aws.amazon.com/cli/): 
-      ```bash
-      conda install -c conda-forge awscli
-      ```
-      or 
-      ```bash
-      pip install awscli
-      ```  
+       ```bash
+       conda install -c conda-forge awscli
+       ```
+       or 
+       ```bash
+       pip install awscli
+       ```
     2) To download the whole dataset (519 GB): 
-      ```bash
-      aws s3 sync --no-sign-request s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .
-      ```  
+       ```bash
+       aws s3 sync --no-sign-request s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .
+       ```
     3) To download subsets of the dataset appropriate query terms can be used, e.g.:  
        the first trajectory of project 11743:
        ```bash
        aws s3 cp --no-sign-request s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer/11743/run0-clone0.h5 .
-       ```  
+       ```
        the first 10 trajectories of project 11743: 
        ```bash
        aws s3 sync --no-sign-request --exclude "*" --include "11743/run0-clone?.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .
@@ -40,7 +40,7 @@ description: >
        the first 100 trajectories of project 11743: 
        ```bash
        aws s3 sync --no-sign-request --exclude "*" --include "11743/run0-clone??.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .
-       ``` 
+       ```
 
   Individual files can also be downloaded directly via HTTP, [for example](https://fah-public-data-covid19-moonshot-dynamics.s3.us-east-2.amazonaws.com/SARS-CoV-2_main_protease_monomer/11743/run0-clone0.h5).    
   Data can also be browsed and downloaded in the AWS Management Console [here](https://s3.console.aws.amazon.com/s3/buckets/fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer).  

--- a/data/simulations/FAH-Mpro-monomer-no-water.yml
+++ b/data/simulations/FAH-Mpro-monomer-no-water.yml
@@ -1,14 +1,12 @@
 type: md
 title: SARS-CoV-2 main protease (apo, monomer) Folding@home simulations
 description: >
-  Folding@home projects 11743 and 11749 are made available here without solvent, but including salt.
-  Both of these projects were initiated from PDB structure `6lu7`, chain A (after removing the inhibitor (i.e. in apo form), as a monomer).
-  The split into two projects is simply the result of the architecture of Folding@home, there are no differences in the setups between these projects.
-  Please note the identical file names in both projects, there is no relation between the identically named files - all trajectories are initialized with different random velocities.
-  Each trajectory is available in the appropriate project folder with trajectory files formatted as `run<RUN>-clone<CLONE>.h5`,
-  with `<RUN>` indexing a set of trajectories started from the same conformation (i.e. all trajectories here are `RUN0`)
-  and `<CLONE>` denoting different replicates initiated from the same structure but different initial velocities.
-  The dataset contains 5688 trajectories - a subset of trajectories longer than 250 ns generated in these Folding@home projects. Frames are saved every 0.2 ns.
+  This is a dataset containing 5688 trajectories at least 250 ns in length (2.6 ms in total) of SARS-CoV-2 main viral protease (Mpro/3CLpro) in its apo, monomeric form. 
+  Water (but not salt) has been stripped from the trajectories, frames are saved every 0.2 ns.
+  Simulations were initiated from PDB structure `6lu7`, chain A, after removing the inhibitor and structural waters.
+  
+  The dataset is organized by Folding@home project number (11743 and 11749) due to the F@h parallelization -- there are no differences in setups between the projects 
+  and there is no relation between the identically named files - all trajectories (`CLONE`s) are initialized with random velocities.
 
   Chain A (i.e. a monomer of the protein, without the inhibitor or waters) was extracted from `6lu7` using PyMOL, and protonated and capped (ACE, NME) with Schrodinger's Maestro.
   Simulations were performed in the NPT ensemble (310 K, 1 atm), in a cubic box with 1 nm padding, 150 mM NaCl, with hydrogen mass repartitioning (4 amu H mass), using `amber14SB` and `tip3p` forcefields.
@@ -16,24 +14,29 @@ description: >
   then for 1.25 ns using 4 fs timestep with OpenMMTools custom Langevin integrator using `V R O R V` splitting.
   All Folding@home trajectories were then seeded with random velocities from this system.
 
-  The dataset is available through both the Open Science Framework and AWS Public Datasets. Links are provided to GUIs for both below.
-  Additionally, the AWS dataset can be accessed through the command line interface (CLI) as follows:
-    1) Install the AWS CLI: `conda install awscli` or `pip install awscli`
-    2) Configure the CLI with your AWS account: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html
-    3) To download the whole dataset (519 GB): `aws s3 sync s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`
-    4) To download subsets of the dataset appropriate query terms can be used, e.g.:
+  The dataset is available through AWS Public Datasets as explained below, as well as Open Science Framework at https://osf.io/d9tm2
+  
+  The AWS dataset can be accessed through the command line interface (CLI) as follows:  
+    1) Install the AWS CLI:  
+      `conda install awscli`  
+      or  
+      `pip install awscli`  
+    2) Configure the CLI with your AWS account: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html  
+    3) To download the whole dataset (519 GB):  
+      `aws s3 sync s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`  
+    4) To download subsets of the dataset appropriate query terms can be used, e.g.:  
        the first trajectory of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone0.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`
        the first 10 trajectories of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone?.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`
        the first 100 trajectories of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone??.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`
 
-  Note that both the AWS Console GUI and the CLI require an AWS account. Individual files can also be downloaded without an AWS account as follows: https://fah-public-data-covid19-moonshot-dynamics.s3.us-east-2.amazonaws.com/SARS-CoV-2_main_protease_monomer/11743/run0-clone0.h5
+  Note that an AWS account is required to use the CLI. Individual files can also be downloaded without an AWS account as follows: https://fah-public-data-covid19-moonshot-dynamics.s3.us-east-2.amazonaws.com/SARS-CoV-2_main_protease_monomer/11743/run0-clone0.h5
+  Data can also be browsed and downloaded in the AWS Management Console at https://s3.console.aws.amazon.com/s3/buckets/fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer
 creator: Rafal Wiewiora, John Chodera
 organization: Folding@home
 lab: Chodera lab
 institute: Memorial Sloan Kettering Cancer Center
 models:
-    - fah-mpro-monomer-all-atom
-    - fah-mpro-monomer-no-water
+    - FAH-Mpro-monomer
 proteins:
     - 3CLpro
 structures:
@@ -42,9 +45,7 @@ molecule:
 rating:
 files:
     - https://github.com/FoldingAtHome/coronavirus/tree/master/system-preparation/6lu7_receptor
-trajectory:
-    - https://s3.console.aws.amazon.com/s3/buckets/fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer
-    - https://osf.io/d9tm2/files/
+trajectory: https://s3.console.aws.amazon.com/s3/buckets/fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer
 size: 519.1 GB
 length: 2.6 ms
 ensemble: NPT

--- a/data/simulations/FAH-Mpro-monomer-no-water.yml
+++ b/data/simulations/FAH-Mpro-monomer-no-water.yml
@@ -1,0 +1,37 @@
+type: md
+title: SARS-CoV-2 main protease (apo, monomer) Folding@home simulations
+description: >
+  Folding@home projects 11743 and 11749 are made available here without solvent, but including salt. Both of these projects were initiated from PDB structure `6lu7`, chain A (after removing the inhibitor (i.e. in apo form), as a monomer). The split into two projects is simply the result of the architecture of Folding@home, there are no differences in the setups between these projects. Please note the identical file names in both projects, there is no relation between the identically named files - all trajectories are initialized with different random velocities. Each trajectory is available in the appropriate project folder with trajectory files formatted as `run<RUN>-clone<CLONE>.h5`, with `<RUN>`` indexing a set of trajectories started from the same conformation (i.e. all trajectories here are `RUN0`) and ``<CLONE>`` denoting different replicates initiated from the same structure but different initial velocities. The dataset contains 5688 trajectories - a subset of trajectories longer than 250 ns generated in these Folding@home projects. 
+  
+  Chain A (i.e. a monomer of the protein, without the inhibitor or waters) was extracted from `6lu7` using PyMOL, and protonated and capped (ACE,NME) with Schrodinger's Maestro. Simulations were performed in the NPT ensemble (310 K, 1 atm), in a cubic box with 1 nm padding, 150 mM NaCl, 4 amu hydrogen mass, using `amber14SB` and `tip3p` forcefields. OpenMM 7.4.1 was used. System was equilibrated for 5 ns using 2 fs timestep with default OpenMM Langevin integrator, production runs used 4 fs timestep with OpenMMTools custom Langevin integrator using `V R O R V` splitting.
+creator: Rafal Wiewiora, John Chodera
+organization: Folding@home
+lab: Chodera lab
+institute: Memorial Sloan Kettering Cancer Center
+models:
+    - fah-mpro-monomer-all-atom
+    - fah-mpro-monomer-no-water
+proteins:
+    - 3CLpro
+structures:
+    - 6LU7
+molecule:
+rating:
+files:
+    - https://github.com/FoldingAtHome/coronavirus/tree/master/system-preparation/6lu7_receptor
+trajectory:
+    - https://s3.console.aws.amazon.com/s3/buckets/fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer
+    - https://osf.io/d9tm2/files/
+size: 519.1 GB
+length: 2.6 ms
+ensemble: NPT
+temperature: 310
+pressure: 1  
+solvent: water
+salinity: 0.15
+forcefields:
+    - amber14SB
+    - tip3p
+references:
+publication:
+preprint:

--- a/data/simulations/FAH-Mpro-monomer-no-water.yml
+++ b/data/simulations/FAH-Mpro-monomer-no-water.yml
@@ -16,20 +16,20 @@ description: >
 
   The dataset is available through AWS Public Datasets and can be accessed through the command line interface (CLI) as follows:  
     
-    1) Install the [AWS CLI](https://aws.amazon.com/cli/):  
+    1) Install the [AWS CLI](https://aws.amazon.com/cli/): 
       ```bash
       conda install -c conda-forge awscli
       ```
-      or  
+      or 
       ```bash
       pip install awscli
       ```  
-    2) To download the whole dataset (519 GB):  
+    2) To download the whole dataset (519 GB): 
       ```bash
       aws s3 sync --no-sign-request s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .
       ```  
     3) To download subsets of the dataset appropriate query terms can be used, e.g.:  
-       the first trajectory of project 11743: 
+       the first trajectory of project 11743:
        ```bash
        aws s3 cp --no-sign-request s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer/11743/run0-clone0.h5 .
        ```  

--- a/data/simulations/FAH-Mpro-monomer-no-water.yml
+++ b/data/simulations/FAH-Mpro-monomer-no-water.yml
@@ -1,9 +1,32 @@
 type: md
 title: SARS-CoV-2 main protease (apo, monomer) Folding@home simulations
 description: >
-  Folding@home projects 11743 and 11749 are made available here without solvent, but including salt. Both of these projects were initiated from PDB structure `6lu7`, chain A (after removing the inhibitor (i.e. in apo form), as a monomer). The split into two projects is simply the result of the architecture of Folding@home, there are no differences in the setups between these projects. Please note the identical file names in both projects, there is no relation between the identically named files - all trajectories are initialized with different random velocities. Each trajectory is available in the appropriate project folder with trajectory files formatted as `run<RUN>-clone<CLONE>.h5`, with `<RUN>`` indexing a set of trajectories started from the same conformation (i.e. all trajectories here are `RUN0`) and ``<CLONE>`` denoting different replicates initiated from the same structure but different initial velocities. The dataset contains 5688 trajectories - a subset of trajectories longer than 250 ns generated in these Folding@home projects. 
-  
-  Chain A (i.e. a monomer of the protein, without the inhibitor or waters) was extracted from `6lu7` using PyMOL, and protonated and capped (ACE,NME) with Schrodinger's Maestro. Simulations were performed in the NPT ensemble (310 K, 1 atm), in a cubic box with 1 nm padding, 150 mM NaCl, 4 amu hydrogen mass, using `amber14SB` and `tip3p` forcefields. OpenMM 7.4.1 was used. System was equilibrated for 5 ns using 2 fs timestep with default OpenMM Langevin integrator, production runs used 4 fs timestep with OpenMMTools custom Langevin integrator using `V R O R V` splitting.
+  Folding@home projects 11743 and 11749 are made available here without solvent, but including salt.
+  Both of these projects were initiated from PDB structure `6lu7`, chain A (after removing the inhibitor (i.e. in apo form), as a monomer).
+  The split into two projects is simply the result of the architecture of Folding@home, there are no differences in the setups between these projects.
+  Please note the identical file names in both projects, there is no relation between the identically named files - all trajectories are initialized with different random velocities.
+  Each trajectory is available in the appropriate project folder with trajectory files formatted as `run<RUN>-clone<CLONE>.h5`,
+  with `<RUN>` indexing a set of trajectories started from the same conformation (i.e. all trajectories here are `RUN0`)
+  and `<CLONE>` denoting different replicates initiated from the same structure but different initial velocities.
+  The dataset contains 5688 trajectories - a subset of trajectories longer than 250 ns generated in these Folding@home projects. Frames are saved every 0.2 ns.
+
+  Chain A (i.e. a monomer of the protein, without the inhibitor or waters) was extracted from `6lu7` using PyMOL, and protonated and capped (ACE, NME) with Schrodinger's Maestro.
+  Simulations were performed in the NPT ensemble (310 K, 1 atm), in a cubic box with 1 nm padding, 150 mM NaCl, with hydrogen mass repartitioning (4 amu H mass), using `amber14SB` and `tip3p` forcefields.
+  OpenMM 7.4.1 was used. System was equilibrated for 5 ns using 2 fs timestep with default OpenMM Langevin integrator,
+  then for 1.25 ns using 4 fs timestep with OpenMMTools custom Langevin integrator using `V R O R V` splitting.
+  All Folding@home trajectories were then seeded with random velocities from this system.
+
+  The dataset is available through both the Open Science Framework and AWS Public Datasets. Links are provided to GUIs for both below.
+  Additionally, the AWS dataset can be accessed through the command line interface (CLI) as follows:
+    1) Install the AWS CLI: `conda install awscli` or `pip install awscli`
+    2) Configure the CLI with your AWS account: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html
+    3) To download the whole dataset (519 GB): `aws s3 sync s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`
+    4) To download subsets of the dataset appropriate query terms can be used, e.g.:
+       the first trajectory of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone0.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`
+       the first 10 trajectories of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone?.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`
+       the first 100 trajectories of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone??.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`
+
+  Note that both the AWS Console GUI and the CLI require an AWS account. Individual files can also be downloaded without an AWS account as follows: https://fah-public-data-covid19-moonshot-dynamics.s3.us-east-2.amazonaws.com/SARS-CoV-2_main_protease_monomer/11743/run0-clone0.h5
 creator: Rafal Wiewiora, John Chodera
 organization: Folding@home
 lab: Chodera lab
@@ -26,7 +49,7 @@ size: 519.1 GB
 length: 2.6 ms
 ensemble: NPT
 temperature: 310
-pressure: 1  
+pressure: 1
 solvent: water
 salinity: 0.15
 forcefields:

--- a/data/simulations/FAH-Mpro-monomer-no-water.yml
+++ b/data/simulations/FAH-Mpro-monomer-no-water.yml
@@ -25,7 +25,9 @@ description: >
       pip install awscli
       ```  
     2) To download the whole dataset (519 GB):  
-      `aws s3 sync --no-sign-request s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`  
+      ```bash
+      aws s3 sync --no-sign-request s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .
+      ```  
     3) To download subsets of the dataset appropriate query terms can be used, e.g.:  
        the first trajectory of project 11743: 
        ```bash

--- a/data/simulations/FAH-Mpro-monomer-no-water.yml
+++ b/data/simulations/FAH-Mpro-monomer-no-water.yml
@@ -16,21 +16,33 @@ description: >
 
   The dataset is available through AWS Public Datasets and can be accessed through the command line interface (CLI) as follows:  
     
-    1) Install the AWS CLI:  
-      `conda install -c conda-forge awscli`  
+    1) Install the [AWS CLI](https://aws.amazon.com/cli/):  
+      ```bash
+      conda install -c conda-forge awscli
+      ```
       or  
-      `pip install awscli`  
-    2) Configure the CLI with your AWS account: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html  
-    3) To download the whole dataset (519 GB):  
-      `aws s3 sync s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`  
-    4) To download subsets of the dataset appropriate query terms can be used, e.g.:  
-       the first trajectory of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone0.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`  
-       the first 10 trajectories of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone?.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`  
-       the first 100 trajectories of project 11743: `aws s3 sync --exclude "*" --include "11743/run0-clone??.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`  
+      ```bash
+      pip install awscli
+      ```  
+    2) To download the whole dataset (519 GB):  
+      `aws s3 sync --no-sign-request s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .`  
+    3) To download subsets of the dataset appropriate query terms can be used, e.g.:  
+       the first trajectory of project 11743: 
+       ```bash
+       aws s3 cp --no-sign-request s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer/11743/run0-clone0.h5 .
+       ```  
+       the first 10 trajectories of project 11743: 
+       ```bash
+       aws s3 sync --no-sign-request --exclude "*" --include "11743/run0-clone?.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .
+       ```
+       the first 100 trajectories of project 11743: 
+       ```bash
+       aws s3 sync --no-sign-request --exclude "*" --include "11743/run0-clone??.h5" s3://fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer .
+       ``` 
 
-  Note that an AWS account is required to use the CLI. Individual files can also be downloaded without an AWS account, for example: https://fah-public-data-covid19-moonshot-dynamics.s3.us-east-2.amazonaws.com/SARS-CoV-2_main_protease_monomer/11743/run0-clone0.h5  
-  Data can also be browsed and downloaded in the AWS Management Console at https://s3.console.aws.amazon.com/s3/buckets/fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer  
-  Alternatively, the dataset is also available through the Open Science Framework at https://osf.io/d9tm2
+  Individual files can also be downloaded directly via HTTP, [for example](https://fah-public-data-covid19-moonshot-dynamics.s3.us-east-2.amazonaws.com/SARS-CoV-2_main_protease_monomer/11743/run0-clone0.h5).    
+  Data can also be browsed and downloaded in the AWS Management Console [here](https://s3.console.aws.amazon.com/s3/buckets/fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer).  
+  Alternatively, the dataset is also available through the Open Science Framework [here](https://osf.io/d9tm2).
 creator: Rafal Wiewiora, John Chodera
 organization: Folding@home
 lab: Chodera lab
@@ -45,7 +57,7 @@ molecule:
 rating:
 files:
     - https://github.com/FoldingAtHome/coronavirus/tree/master/system-preparation/6lu7_receptor
-trajectory: https://s3.console.aws.amazon.com/s3/buckets/fah-public-data-covid19-moonshot-dynamics/SARS-CoV-2_main_protease_monomer
+trajectory: https://registry.opendata.aws/foldingathome-covid19
 size: 519.1 GB
 length: 2.6 ms
 ensemble: NPT

--- a/data/simulations/FAH-Mpro-monomer-no-water.yml
+++ b/data/simulations/FAH-Mpro-monomer-no-water.yml
@@ -8,7 +8,8 @@ description: >
   The dataset is organized by Folding@home project number (11743 and 11749) due to the F@h parallelization -- there are no differences in setups between the projects 
   and there is no relation between the identically named files - all trajectories (`CLONE`s) are initialized with random velocities.
 
-  Chain A (i.e. a monomer of the protein, without the inhibitor or waters) was extracted from `6lu7` using PyMOL, and protonated and capped (ACE, NME) with Schrodinger's Maestro.
+  Chain A (i.e. a monomer of the protein, without the inhibitor or waters) was extracted from [6lu7](http://www.rcsb.org/structure/6LU7) using PyMOL, and protonated and capped (ACE, NME) with Schrodinger's Maestro.
+  The model can be downloaded [here](https://github.com/FoldingAtHome/coronavirus/blob/master/system-preparation/6lu7_receptor/output/solvated.pdb).
   Simulations were performed in the NPT ensemble (310 K, 1 atm), in a cubic box with 1 nm padding, 150 mM NaCl, with hydrogen mass repartitioning (4 amu H mass), using `amber14SB` and `tip3p` forcefields.
   OpenMM 7.4.1 was used. System was equilibrated for 5 ns using 2 fs timestep with default OpenMM Langevin integrator,
   then for 1.25 ns using 4 fs timestep with OpenMMTools custom Langevin integrator using `V R O R V` splitting.


### PR DESCRIPTION
## Description
Adding 2.6 ms, 5688 trajectories Folding@home Mpro/3CLpro monomer dataset hosted on AWS/OSF. 

## Status
- [x] YAML file for each piece of data
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


