### PR TITLE
Anchor links for submitted data

### DIFF
--- a/themes/minimal/layouts/partials/model-entry.html
+++ b/themes/minimal/layouts/partials/model-entry.html
@@ -10,10 +10,12 @@
 <div class="col col-9">
 
       <!-- Model name -->
-      <h4 align="center" class="anchor" id='{{ print ( .model.name | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize)}}'>
+      {{ $entry_name := ( print ( .model.name | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize) ) }}
+      <h4 align="center" class="anchor" id='{{ $entry_name }}'>
           {{ .model.name }}
           {{ with .model.rating }} {{ range $i, $sequence := (seq .) }}★{{ end }} {{ end }}
           {{ partial "general-marker" .model }}
+          <a href='{{ print .context.Site.BaseURL "/models/#" $entry_name }}'><i class="fa fa-link" aria-hidden="true"></i></a>
       </h4>
 
       <!-- Author -->

--- a/themes/minimal/layouts/partials/protein-entry.html
+++ b/themes/minimal/layouts/partials/protein-entry.html
@@ -8,7 +8,10 @@
 <div class="col col-9">
 
     <!-- protein name -->
-    <h4 align="center" class="anchor" id="{{ .protein.name | anchorize }}"><b>{{ .protein.name }}</b></h4>
+    {{ $entry_name := ( .protein.name | anchorize ) }}
+    <h4 align="center" class="anchor" id="{{ .protein.name | anchorize }}"><b>{{ .protein.name }}</b>
+        <a href='{{ print .context.Site.BaseURL "/proteins/#" $entry_name }}'><i class="fa fa-link" aria-hidden="true"></i></a>
+    </h4>
 
     <!-- protein description -->
     <h5 align="justify">{{ .protein.description | markdownify }}</h5>

--- a/themes/minimal/layouts/partials/simulation-entry.html
+++ b/themes/minimal/layouts/partials/simulation-entry.html
@@ -10,14 +10,16 @@
 
 <div class="col col-9">
 
-        <!-- Model name -->
-        <h4 class="anchor" id='{{ print ( .simulation.title | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize)}}'>
+        <!-- Simulation name -->
+        {{ $entry_name := ( print ( .simulation.title | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize) ) }}
+        <h4 class="anchor" id='{{ $entry_name }}'>
             {{ .simulation.title }}
             {{ if .simulation.length }}
             ({{ .simulation.length }} )
             {{ end }}
             {{ with .simulation.rating }} {{ range $i, $sequence := (seq .) }}★{{ end }} {{ end }}
             {{ partial "general-marker" .simulation }}
+            <a href='{{ print .context.Site.BaseURL "/simulations/#" $entry_name }}'><i class="fa fa-link" aria-hidden="true"></i></a>
         </h4>
         
 <!-- Author -->
@@ -73,7 +75,9 @@
             <b>Input and Supporting Files:</b>
             {{ if .simulation.files }}
                 {{ range (seq (len .simulation.files)) }}
-                    <a href="{{ index $.simulation.files (sub . 1) }}"><kbd class="alert-secondary">[.]</kbd></a>
+                    {{ $file_url := index $.simulation.files (sub . 1) }}  <!-- URL in the YAML -->
+                    {{ $file_last_item := index (last 1 (split $file_url "/")) 0 }} <!-- Filename -->
+                    <p><a href="{{ index $file_url }}"><kbd class="alert-secondary"> {{ $file_last_item }} </kbd></a></p>
                 {{ end }}
             {{ else }}
                 ---

--- a/themes/minimal/layouts/partials/structure-entry.html
+++ b/themes/minimal/layouts/partials/structure-entry.html
@@ -45,8 +45,10 @@
 
 
   <!-- Structure name -->
-  <h4 align="center" class="anchor" id='{{ print ($pdb | anchorize) "-" ( .protein | anchorize) }}'>
+  {{ $entry_name := ( print ($pdb | anchorize) "-" ( .protein | anchorize) ) }}
+  <h4 align="center" class="anchor" id='{{ $entry_name }}'>
     <b>{{ $title }} {{ with .structure.rating }} {{ range $i, $sequence := (seq .) }}★{{ end }} {{ end }} {{ partial "structure-marker" .structure }} </b>
+    <a href='{{ print .context.Site.BaseURL "/structures/#" $entry_name }}'><i class="fa fa-link" aria-hidden="true"></i></a>
   </h4>
 
   <!-- Structure Annotation -->


### PR DESCRIPTION
## Description
Simulations, Models, Structures, and Proteins now have link icons
which allow people to get the direct link to each entry next to it.

Uses the link icon which comes with font-awesome lib which is included
in the whole site through the bootstrap cdn.


## Status
- [x] YAML file for each piece of data
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


