### PR TITLE
Add model for F@H Sims to reference, xref targets by protein as well

### DIFF
--- a/data/models/fah-main-protease-md-model.yml
+++ b/data/models/fah-main-protease-md-model.yml
@@ -1,0 +1,22 @@
+name: "SARS-CoV-2 main protease model for MD simulations"
+description: >
+  Model of the main protease (Mpro/3cl) of SARS-CoV-2 virus.
+
+
+  Structures used for these simulations were obtained using x-ray crystallography from Diamond Light Source via Tim Dudgeon.
+
+
+  A directory of all structures used can be found on our AWS bucket using the [AWS CLI](https://aws.amazon.com/cli/):
+    ```bash
+      aws s3 --no-sign-request sync s3://fah-public-data-covid19-absolute-free-energy/receptor_structures .
+    ```
+  These conformations were used for all listed simulations pertaining to absolute free energy of protease inhibitors. A detailed database of which receptor was used for each simulation can be found in the dataframe listed in the url field.
+
+url: https://fah-public-data-covid19-absolute-free-energy.s3.us-east-2.amazonaws.com/free_energy_data/organization.pkl
+pdb_url: https://fah-public-data-covid19-absolute-free-energy.s3.us-east-2.amazonaws.com/receptor_structures.tar.gz
+proteins:
+  - 3CLpro
+creator: Matt Hurley
+organization: Temple University
+institution: Chemistry Department
+lab: Voelz Lab

--- a/data/proteins/spike.yml
+++ b/data/proteins/spike.yml
@@ -3,7 +3,7 @@ name: SARS-CoV-2 Spike (S) glycoprotein
 organism: SARS-CoV-2
 description: >
   The external glyocoprotein of the virus envelope required for fusion and entry into human host cells.
-target:
+targets:
   - spike binding
   - spike cleavage
   - viral fusion

--- a/data/simulations/FAH_SARS-CoV-2_Mpro_FEP.yml
+++ b/data/simulations/FAH_SARS-CoV-2_Mpro_FEP.yml
@@ -91,6 +91,8 @@ proteins:
     - 3CLpro
 structures:
     - 6Y84
+models:
+    - fah-main-protease-md-model
 trajectory: https://fah-public-data-covid19-absolute-free-energy.s3.us-east-2.amazonaws.com/SVR51748107/PROJ14721/RUN0/CLONE0/results0/traj_comp.xtc
 size: 34 TB
 length: 5.2 ms

--- a/themes/minimal/layouts/partials/list-model-targets.html
+++ b/themes/minimal/layouts/partials/list-model-targets.html
@@ -17,4 +17,18 @@
     {{ end }}
 {{ end }}
 
+{{ range .model.proteins }}
+    {{ $localScratch.Set "model_protein" . }}
+    {{ range $.context.Site.Data.proteins }}
+        {{ $localScratch.Set "protein" . }}
+        {{ $model_protein := ($localScratch.Get "model_protein" | upper) }}
+        {{ if eq (.protein | upper) $model_protein }}
+            {{ if ($localScratch.Get "protein").targets }}
+                {{ $targets := partial "ensure-slice" ($localScratch.Get "protein").targets }}
+                {{ $localScratch.Set "targets" (($localScratch.Get "targets") | append $targets )}}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
 {{ return (uniq ($localScratch.Get "targets")) }}

--- a/themes/minimal/layouts/partials/list-simulation-targets.html
+++ b/themes/minimal/layouts/partials/list-simulation-targets.html
@@ -14,4 +14,18 @@
     {{ end }}
 {{ end }}
 
+{{ range .simulation.proteins }}
+    {{ $localScratch.Set "sim_protein" . }}
+    {{ range $.context.Site.Data.proteins }}
+        {{ $localScratch.Set "protein" . }}
+        {{ $sim_protein := ($localScratch.Get "sim_protein" | upper) }}
+        {{ if eq (.protein | upper) $sim_protein }}
+            {{ if ($localScratch.Get "protein").targets }}
+                {{ $targets := partial "ensure-slice" ($localScratch.Get "protein").targets }}
+                {{ $localScratch.Set "targets" (($localScratch.Get "targets") | append $targets )}}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
 {{ return (uniq ($localScratch.Get "targets")) }}


### PR DESCRIPTION
## Description
This PR adds the model for the F@H simulation, cc @yabmtm @jchodera

This also allows models to cross-reference their targets by listed
proteins as well as PDB ID structures. Should be compatible with all
other existing models as well.

## Status
- [x] YAML file for each piece of data
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


