### PR TITLE
Add "Contributions By Organization"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -130,12 +130,18 @@ ignoreFiles = ["README.md$"]
         url = "/contributors/"
         name = "Contributors"
         weight = 1
+
+    [[menu.main]]
+        parent = "Contribution"
+        url = "/org-contributions"
+        name = "Contributions by Organization"
+        weight = 2
     
     [[menu.main]]
         parent = "Contribution"
         url = "/contributing/"
         name = "How to Contribute"
-        weight = 2
+        weight = 3
 
 
 [[menu.main]]

--- a/content/org-contributions.md
+++ b/content/org-contributions.md
@@ -1,0 +1,10 @@
+---
+title: Contributions by Organization
+description: Thank you to all of our contributors!
+type: org-contributions
+---
+We would like to thank all the people who contributed to the COVID-19 Molecular Structure and Therapeutics Hub. Each member of this list has contributed their time in providing advice, development help, and/or data to the hub.
+
+This page lists all the data contributions by organization sorted by type. [Click here to see]({{< ref "/contributors" >}} "Contributors") the list of individual contributors.
+
+

--- a/data/organizations/README.md
+++ b/data/organizations/README.md
@@ -13,6 +13,7 @@ short: (optional) Short name or acronym if people want it
 logo: (optional) name of the logo file in the /static/images/org-logos directory
 url: (optional) Link to the organization
 endorsement_logo: (optional) Indicates that this org is endorsing the Hub, and then uses this logo path in /static/images/org-logos
+alt_names: (optional) List of alternate names the org can be known under as a string.
 ```
 
 ### Visual Display Caveat

--- a/data/organizations/desres.yml
+++ b/data/organizations/desres.yml
@@ -2,3 +2,5 @@ name: D. E. Shaw Research
 logo: DESRES_Logo_K.svg
 url: https://www.deshawresearch.com/
 endorsement_logo: DESRES_Logo_K.svg
+alt_names:
+  - DESRES

--- a/data/organizations/fah.yml
+++ b/data/organizations/fah.yml
@@ -2,3 +2,7 @@ name: Folding @ Home
 logo: fah.png
 url: https://foldingathome.org/
 endorsement_logo: fah.png
+alt_names:
+  - fah
+  - f@h
+  - folding at home

--- a/schema/validation.py
+++ b/schema/validation.py
@@ -380,6 +380,7 @@ class OrganizationModel(BaseModel):
     logo: Optional[str]
     url: Optional[AnyUrl]
     endorsement_logo: Optional[str]
+    alt_names: Optional[List[str]]
 
 
 class ContributorMemberModel(BaseModel):

--- a/themes/minimal/layouts/contributors/single.html
+++ b/themes/minimal/layouts/contributors/single.html
@@ -11,7 +11,7 @@
         {{ .Content }}
     </div>
     <hr>
-    <!-- List all targets from data/targets/ -->
+    <!-- List all targets from data/contributors/ -->
     {{ range $.Site.Data.contributors }}
        {{ partial "contributors.html" (dict "contrib" . "context" $)}}
     {{ end }}

--- a/themes/minimal/layouts/org-contributions/single.html
+++ b/themes/minimal/layouts/org-contributions/single.html
@@ -1,0 +1,94 @@
+{{ partial "header" . }}
+
+{{ $localScratch := newScratch }}
+<main>
+
+    <div>
+        <h2>{{ .Title }}</h2>
+        <!--<h5>{{ .Description }}</h5>-->
+        {{ partial "tags" . }}
+    </div>
+    <div align="justify">
+        {{ .Content }}
+    </div>
+    <hr>
+    <!-- List all targets from data/organizations/ -->
+    {{ range $.Site.Data.organizations }}
+        {{ $localScratch.Set "name" .name }}
+        <!-- Compose all names the org could be -->
+        {{ $localScratch.Set "org_names" (slice (replace .name " " "" | upper )) }} <!-- Strip spaces, cast upper -->
+        {{ range .alt_names }}
+            {{ $names := $localScratch.Get "org_names" }}
+            {{ $names := $names | append (replace . " " "" | upper ) }} <!-- Strip spaces, cast upper -->
+            {{ $localScratch.Set "org_names" $names }} <!-- Reassign to global variable -->
+        {{ end }}
+
+        <!-- Check if it has content first -->
+        {{ $localScratch.Set "has_content_models" false }}
+        {{ $localScratch.Set "has_content_sims" false }}
+        <!-- Loop over Models and Simulations-->
+        {{ range $.Site.Data.models }}
+            {{ $made_by_org := partial "made-by-org.html" (dict "org" ($localScratch.Get "org_names") "data" .) }}
+            {{ if $made_by_org }}
+                {{ $localScratch.Set "has_content_models" true }}
+            {{ end }}
+        {{ end }}
+        {{ range $.Site.Data.simulations }}
+            {{ $made_by_org := partial "made-by-org.html" (dict "org" ($localScratch.Get "org_names") "data" .) }}
+            {{ if $made_by_org }}
+                {{ $localScratch.Set "has_content_sims" true }}
+            {{ end }}
+        {{ end }}
+
+        {{ if or ($localScratch.Get "has_content_sims") ($localScratch.Get "has_content_models")}}
+            {{ $org := $localScratch.Get "name" | title}}
+            {{ $org_anchor := $org | anchorize }}
+            <h3 align="center" class="anchor" id='{{ $org_anchor }}'>
+                Contributions by the {{ $org }} Organization
+                <a href='{{ print $.Site.BaseURL "/org-contributions/#" $org_anchor }}'><i class="fa fa-link" aria-hidden="true"></i></a>
+            </h3>
+            {{ if ($localScratch.Get "has_content_models") }}
+                <h4 align="left" class="anchor" id='{{print  $org_anchor "-models"}}'>
+                    {{ $org }}'s Models
+                    <a href='{{ print $.Site.BaseURL "/org-contributions/#" $org_anchor "-models" }}'><i class="fa fa-link" aria-hidden="true"></i></a>
+                </h4>
+                {{ range $.Site.Data.models }}
+                    {{ $made_by_org := partial "made-by-org.html" (dict "org" ($localScratch.Get "org_names") "data" .) }}
+                    {{ if $made_by_org }}
+                        {{ $entry_name := print ( .name | anchorize) }}
+                            <a href='{{ print $.Site.BaseURL "/models/#" $entry_name }}'>
+                                <h5 align="left" class="anchor" id='{{ $entry_name }}'>
+                                    {{ .name }}
+                                    {{ partial "general-marker" . }}
+                                </h5>
+                            </a>
+                    {{ end }}
+                {{ end }}
+            {{ end }}
+            {{ if ($localScratch.Get "has_content_sims") }}
+                <h4 align="left" class="anchor" id='{{print  $org_anchor "-sims"}}'>
+                    {{ $org }}'s Simulations
+                    <a href='{{ print $.Site.BaseURL "/org-contributions/#" $org_anchor "-sims" }}'><i class="fa fa-link" aria-hidden="true"></i></a>
+                </h4>
+                {{ range $.Site.Data.simulations }}
+                    {{ $made_by_org := partial "made-by-org.html" (dict "org" ($localScratch.Get "org_names") "data" .) }}
+                    {{ if $made_by_org }}
+                        {{ $entry_name := print ( .title | anchorize) }}
+                            <a href='{{ print $.Site.BaseURL "/simulations/#" $entry_name }}'>
+                                <h5 align="left" class="anchor" id='{{ $entry_name }}'>
+                                    {{ .title }}
+                                    {{ partial "general-marker" . }}
+                                </h5>
+                            </a>
+                    {{ end }}
+                {{ end }}
+            {{ end }}
+            <hr class="hr-thick">
+        {{ end }}
+    {{ end }}
+
+    <hr>
+
+</main>
+
+{{ partial "footer" . }}

--- a/themes/minimal/layouts/org-contributions/single.html
+++ b/themes/minimal/layouts/org-contributions/single.html
@@ -56,12 +56,12 @@
                     {{ $made_by_org := partial "made-by-org.html" (dict "org" ($localScratch.Get "org_names") "data" .) }}
                     {{ if $made_by_org }}
                         {{ $entry_name := print ( .name | anchorize) }}
-                            <a href='{{ print $.Site.BaseURL "/models/#" $entry_name }}'>
-                                <h5 align="left" class="anchor" id='{{ $entry_name }}'>
+                            <p align="left">
+                                <a href='{{ print $.Site.BaseURL "/models/#" $entry_name }}'>
                                     {{ .name }}
                                     {{ partial "general-marker" . }}
-                                </h5>
-                            </a>
+                                </a>
+                            </p>
                     {{ end }}
                 {{ end }}
             {{ end }}
@@ -74,12 +74,12 @@
                     {{ $made_by_org := partial "made-by-org.html" (dict "org" ($localScratch.Get "org_names") "data" .) }}
                     {{ if $made_by_org }}
                         {{ $entry_name := print ( .title | anchorize) }}
-                            <a href='{{ print $.Site.BaseURL "/simulations/#" $entry_name }}'>
-                                <h5 align="left" class="anchor" id='{{ $entry_name }}'>
+                            <p align="left">
+                                <a href='{{ print $.Site.BaseURL "/simulations/#" $entry_name }}'>
                                     {{ .title }}
                                     {{ partial "general-marker" . }}
-                                </h5>
-                            </a>
+                                </a>
+                            </p>
                     {{ end }}
                 {{ end }}
             {{ end }}

--- a/themes/minimal/layouts/partials/made-by-org.html
+++ b/themes/minimal/layouts/partials/made-by-org.html
@@ -1,0 +1,28 @@
+{{ $localScratch := newScratch }}
+{{ $localScratch.Set "made" false }}
+
+{{ if isset .data "organization" }}
+    {{ if in $.org (replace $.data.organization " " "" | upper) }}
+        {{ $localScratch.Set "made" true }}
+    {{ end }}
+{{ end }}
+
+{{ if isset .data "creator" }}
+    {{ if in $.org (replace $.data.creator " " "" | upper) }}
+        {{ $localScratch.Set "made" true }}
+    {{ end }}
+{{ end }}
+
+{{ if isset .data "institution" }}
+    {{ if in $.org (replace $.data.institution " " "" | upper) }}
+        {{ $localScratch.Set "made" true }}
+    {{ end }}
+{{ end }}
+
+{{ if isset .data "lab" }}
+    {{ if in $.org (replace $.data.lab " " "" | upper) }}
+        {{ $localScratch.Set "made" true }}
+    {{ end }}
+{{ end }}
+
+{{ return $localScratch.Get "made" }}

--- a/themes/minimal/layouts/partials/model-entry.html
+++ b/themes/minimal/layouts/partials/model-entry.html
@@ -10,8 +10,10 @@
 <div class="col col-9">
 
       <!-- Model name -->
-      {{ $entry_name := ( print ( .model.name | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize) ) }}
+      {{ $entry_id := ( print ( .model.name | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize) ) }}
+      {{ $entry_name := .model.name | anchorize }}
       <h4 align="center" class="anchor" id='{{ $entry_name }}'>
+          <span class="anchor" id="{{ $entry_id }}"></span> <!-- This is to make the anchor work without breaking anything previous-->
           {{ .model.name }}
           {{ with .model.rating }} {{ range $i, $sequence := (seq .) }}★{{ end }} {{ end }}
           {{ partial "general-marker" .model }}

--- a/themes/minimal/layouts/partials/simulation-entry.html
+++ b/themes/minimal/layouts/partials/simulation-entry.html
@@ -11,8 +11,10 @@
 <div class="col col-9">
 
         <!-- Simulation name -->
-        {{ $entry_name := ( print ( .simulation.title | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize) ) }}
+        {{ $entry_id := ( print ( .simulation.title | anchorize) "-" ( .protein | anchorize) "-" ( .target | anchorize) ) }}
+        {{ $entry_name := .simulation.title | anchorize }}
         <h4 class="anchor" id='{{ $entry_name }}'>
+            <span class="anchor" id="{{ $entry_id }}"></span> <!-- This is to make the anchor work without breaking any previous links-->
             {{ .simulation.title }}
             {{ if .simulation.length }}
             ({{ .simulation.length }} )


### PR DESCRIPTION
## Description
Adds a contribution by organization page which handily lists all
the contributions from a single organization, auto-populated from the
`data/organizations` directory and based on the
creator/organization/lab/institute fields of every `model` and `simulation.`

Each Org listed this way has the ability to grab the URL to that master
list on the page itself.

Page can be found by the top level navigation under the
"Contribution -> Contributions by Organization" header.

Also made a small change to the entry anchors so URL's can be a bit shorter.
Old URL's will continue to work.

Added the ability have alternate names and spellings for organizations
which are automatically compared against for who contributed what data.
This is all case and whitespace insensitive.

Fixes #158 

cc @jchodera 

## Status
- [x] YAML file for each piece of data
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


