### PR TITLE
SIRAH CG MD PDBs 6XDC, 6ZSL, 6XEY and some typos

### DIFF
--- a/data/simulations/SIRAH-CoV2-Glycosylated_RBD-PDB_6VSB.yml
+++ b/data/simulations/SIRAH-CoV2-Glycosylated_RBD-PDB_6VSB.yml
@@ -4,7 +4,7 @@ description: >
     This dataset contains the trajectories of 10 microseconds-long coarse-grained molecular dynamics simulations of SARS-CoV2 Spike´s RBD glycosylated at Asn331 and Asn343. The initial coordinates correspond to amino acids 327 to 532 taken from the PDB structure 6VSB. Missing loops and glycosylation trees were added with [CHARMM-GUI](http://www.charmm-gui.org).
 
 
-    There are two different sets of simulations corresponding to Core Complex and High Mannose. Simulations have been performed using the SIRAH force field running with the Amber18 package at the Uruguayan National Center for Supercomputing (ClusterUY) under the conditions reported in [Machado et al. JCTC 2019](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00006), adding 150 mM NaCl according to [Machado & Pantano JCTC 2020](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00953). Glycan parameters will be published soon.
+    There are two different sets of simulations corresponding to Core Complex and High Mannose. Simulations have been performed using the SIRAH force field running with the Amber18 package at the Uruguayan National Center for Supercomputing (ClusterUY) under the conditions reported in [Machado et al. JCTC 2019](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00006), adding 150 mM NaCl according to [Machado & Pantano JCTC 2020](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00953). Glycan were parameterized as reported in [Garay et at. 2020](https://www.biorxiv.org/content/10.1101/2020.12.18.423446v1).
 
 
     The files **RBD-Man9_SIRAHcg_rawdata_0-6us.tar** and **RBD-Man9_SIRAHcg_rawdata_6-10us.tar**, contain all the raw information required to visualize (on VMD), analyze, backmap the simulations. Analogous information for Core-complex glycosylations is contained in files **RBD-Core-complex_SIRAHcg_rawdata_0-6us.tar** and **RBD-Core-complex_SIRAHcg_rawdata_6-10us.tar**.
@@ -53,3 +53,4 @@ references:
     - "Machado, M. R.; Barrera, E. E.; Klein, F.; Sóñora, M.; Silva, S.; Pantano, S. The SIRAH 2.0 Force Field: Altius, Fortius, Citius. J. Chem. Theory Comput. 2019, acs.jctc.9b00006. https://doi.org/10.1021/acs.jctc.9b00006."
     - "Machado, M. R.; Pantano, S. Split the Charge Difference in Two! A Rule of Thumb for Adding Proper Amounts of Ions in MD Simulations. J. Chem. Theory Comput. 2020, 16 (3), 1367–1372. https://doi.org/10.1021/acs.jctc.9b00953."
     - "Machado, M. R.; Pantano, S. SIRAH Tools: Mapping, Backmapping and Visualization of Coarse-Grained Models. Bioinformatics 2016, 32 (10), 1568–1570. https://doi.org/10.1093/bioinformatics/btw020."
+    - "Garay, P. G.; Machado, M. R.; Verli, H.; Pantano, S. SIRAH Late Harvest: Coarse-Grained Models for Protein Glycosylation. bioRxiv 2020. https://doi.org/10.1101/2020.12.18.423446."

--- a/data/simulations/SIRAH-CoV2-Helicase-PDB_6ZSL.yml
+++ b/data/simulations/SIRAH-CoV2-Helicase-PDB_6ZSL.yml
@@ -1,0 +1,48 @@
+type: md-cg
+title: SIRAH-CoV2 initiative - Helicase
+description: >
+    This dataset contains the trajectory of a 10 microseconds-long coarse-grained molecular dynamics simulation of SARS-CoV2 Helicase protein (PDB id:6ZSL). Simulations were performed using the SIRAH force field running with the Amber18 package at the Uruguayan National Center for Supercomputing (ClusterUY) under the conditions reported in [Machado et al. JCTC 2019](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00006), adding 150 mM NaCl according to [Machado & Pantano JCTC 2020](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00953). Zinc ions were parameterized as reported in [Klein et al. 2020](https://pubs.acs.org/doi/10.1021/acs.jcim.0c00160).
+
+
+    The file **6ZSL_SIRAHcg_rawdata_0-4us.tar**, **6ZSL_SIRAHcg_rawdata_4-8us.tar**, and **6ZSL_SIRAHcg_rawdata_8-10us.tar** contains all the raw information required to visualize (on VMD), analyze, backmap, and eventually continue the simulations using Amber18 or higher. Step-By-Step tutorials for running, visualizing, and analyzing CG trajectories using SirahTools can be found at [SIRAH website](http://www.sirahff.com). Additionally, the file **6ZSL_SIRAHcg_10us_prot.tar ** contains only the protein coordinates, while **6ZSL_SIRAHcg_10us_prot_skip10ns.tar** contains one frame every 10ns.
+
+
+    To take a quick look at the trajectory:
+
+
+    1- Untar the file `6ZSL_SIRAHcg_10us_prot_skip10ns.tar`
+
+
+    2- Open the trajectory on VMD using the command line:
+
+
+    ```
+    vmd 6ZSL_SIRAHcg_prot.prmtop 6ZSL_SIRAHcg_prot_10us_skip10ns.ncrst 6ZSL_SIRAHcg_prot_10us_skip10ns.nc -e sirah_vmdtk.tcl
+    ```
+
+
+    Note that you can use normal VMD drawing methods as vdw, licorice, etc., and coloring by restype, element, name, etc.
+
+
+creator: Pablo Garay
+organization: Institut Pasteur de Montevideo
+lab: Biomolecular Simulations Laboratory
+proteins:
+    - Helicase
+structures:
+    - 6ZSL
+trajectory: https://zenodo.org/record/4250123/
+size: 12.5 GB
+length: 10 µs
+ensemble: NPT
+temperature: 300
+pressure: 1
+solvent: water
+salinity: 0.15
+forcefields:
+    - SIRAH 2.2
+references:
+    - "Machado, M. R.; Barrera, E. E.; Klein, F.; Sóñora, M.; Silva, S.; Pantano, S. The SIRAH 2.0 Force Field: Altius, Fortius, Citius. J. Chem. Theory Comput. 2019, acs.jctc.9b00006. https://doi.org/10.1021/acs.jctc.9b00006."
+    - "Machado, M. R.; Pantano, S. Split the Charge Difference in Two! A Rule of Thumb for Adding Proper Amounts of Ions in MD Simulations. J. Chem. Theory Comput. 2020, 16 (3), 1367–1372. https://doi.org/10.1021/acs.jctc.9b00953."
+    - "Machado, M. R.; Pantano, S. SIRAH Tools: Mapping, Backmapping and Visualization of Coarse-Grained Models. Bioinformatics 2016, 32 (10), 1568–1570. https://doi.org/10.1093/bioinformatics/btw020."
+    - "Klein, F.; Caceres-Rojas, D.; Carrasco, M.; Tapia, J. C.; Caballero, J.; Alzate-Morales, J. H.; Pantano, S. Coarse-Grained Parameters for Divalent Cations within the SIRAH Force Field. J. Chem. Inf. Model. 2020, acs.jcim.0c00160. https://doi.org/10.1021/acs.jcim.0c00160."

--- a/data/simulations/SIRAH-CoV2-Membrane_embedded_ORF3a-PDB_6XDC.yml
+++ b/data/simulations/SIRAH-CoV2-Membrane_embedded_ORF3a-PDB_6XDC.yml
@@ -1,0 +1,48 @@
+type: md-cg
+title: SIRAH-CoV2 initiative - Membrane embedded ORF3a
+description: >
+    This dataset contains the trajectory of a 10 microseconds-long coarse-grained molecular dynamics simulation of the SARS-CoV2 ORF3a dimeric transmembrane protein (PDB id: 6XDC, Bioassembly 1) embedded in a membrane patch containing POPE, POPC, and POPS phospholipids in a 2:1:1 proportion. Simulations have been performed using the SIRAH force field running with the Amber18 package at the Uruguayan National Center for Supercomputing (ClusterUY) under the conditions reported in [Barrera et al. JCTC 2019](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00435), adding 150 mM NaCl according to [Machado & Pantano JCTC 2020](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00953).
+
+
+    The files **6XDC_SIRAHcg_rawdata_0-2us.tar**, **6XDC_SIRAHcg_rawdata_2-4us.tar**, **6XDC_SIRAHcg_rawdata_4-6us.tar**, **6XDC_SIRAHcg_rawdata_6-8us.tar**, and **6XDC_SIRAHcg_rawdata_8-10us.tar** contain all the raw information required to visualize (on VMD 1.9.3), analyze, backmap, and eventually continue the simulations using Amber18 or higher. Step-By-Step tutorials for running, visualizing, and analyzing CG trajectories using [SirahTools](https://academic.oup.com/bioinformatics/article/32/10/1568/1743152) can be found at [SIRAH website](http://www.sirahff.com).
+
+
+    Additionally, the file **6XDC_SIRAHcg_10us_prot-memb_skip10ns.tar** contains only the protein and phospholipids´ coordinates, with one frame every 10ns.
+
+    To take a quick look at the trajectory:
+
+
+    1- Untar the file `6XDC_SIRAHcg_10us_prot-memb_skip10ns.tar`
+
+
+    2- Open the trajectory on VMD using the command line:
+    ```
+    vmd 6XDC_SIRAHcg_prot-memb_skip10ns.prmtop 6XDC_SIRAHcg_prot-memb_10us_skip10ns.ncrst 6XDC_SIRAHcg_prot-memb_10us_skip10ns.nc -e sirah_vmdtk.tcl
+    ```
+
+
+    Note that you can use normal VMD drawing methods as vdw, licorice, etc., and coloring by restype, element, name, etc. 
+
+
+creator: Exequiel Barrera
+organization: Institut Pasteur de Montevideo
+lab: Biomolecular Simulations Laboratory
+proteins:
+  - ORF3a
+structures:
+    - 6XDC
+trajectory: https://zenodo.org/record/4044378/
+size: 43 GB
+length: 10 µs
+ensemble: NPT
+temperature: 300
+pressure: 1
+solvent: water
+salinity: 0.15
+forcefields:
+    - SIRAH 2.2
+references:
+    - "Machado, M. R.; Barrera, E. E.; Klein, F.; Sóñora, M.; Silva, S.; Pantano, S. The SIRAH 2.0 Force Field: Altius, Fortius, Citius. J. Chem. Theory Comput. 2019, acs.jctc.9b00006. https://doi.org/10.1021/acs.jctc.9b00006."
+    - "Machado, M. R.; Pantano, S. Split the Charge Difference in Two! A Rule of Thumb for Adding Proper Amounts of Ions in MD Simulations. J. Chem. Theory Comput. 2020, 16 (3), 1367–1372. https://doi.org/10.1021/acs.jctc.9b00953."
+    - "Machado, M. R.; Pantano, S. SIRAH Tools: Mapping, Backmapping and Visualization of Coarse-Grained Models. Bioinformatics 2016, 32 (10), 1568–1570. https://doi.org/10.1093/bioinformatics/btw020."
+    - "Barrera, E. E.; Machado, M. R.; Pantano, S. Fat SIRAH: Coarse-Grained Phospholipids To Explore Membrane–Protein Dynamics. J. Chem. Theory Comput. 2019, 15 (10), 5674–5688. https://doi.org/10.1021/acs.jctc.9b00435."

--- a/data/simulations/SIRAH-CoV2-RBD_triple_glycosylated-PDB_6XEY.yml
+++ b/data/simulations/SIRAH-CoV2-RBD_triple_glycosylated-PDB_6XEY.yml
@@ -1,0 +1,50 @@
+type: md-cg
+title: SIRAH-CoV2 initiative - RBD triple glycosylated at Asn331, 343, and 481
+description: >
+    This dataset contains the trajectory of a 10 microseconds-long coarse-grained molecular dynamics simulation of a Spike's RBD from SARS-CoV2 glycosylated at Asn331, 343, and 481 with Man9 glycosylation trees. The initial coordinates correspond to amino acids 327 to 532 taken from the PDB structure 6XEY. Missing loops and glycosylation trees were added with [CHARMM-GUI](http://www.charmm-gui.org). Simulations have been performed using the SIRAH force field running with the Amber18 package at the Uruguayan National Center for Supercomputing (ClusterUY) under the conditions reported in [Machado et al. JCTC 2019](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00006), adding 150 mM NaCl according to [Machado & Pantano JCTC 2020](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00953). Glycan were parameterized as reported in [Garay et at. 2020](https://www.biorxiv.org/content/10.1101/2020.12.18.423446v1).
+
+
+    The files **6XEY-RBD-3Man9_SIRAHcg_0-4us.tar**, **6XEY-RBD-3Man9_SIRAHcg_4-8us.tar**, and **6XEY-RBD-3Man9_SIRAHcg_8-10us.tar**, contain all the raw information required to visualize (on VMD), analyze, backmap the simulations. Step-By-Step tutorials for running, visualizing, and analyzing CG trajectories using [SirahTools](https://academic.oup.com/bioinformatics/article/32/10/1568/1743152) can be found at [SIRAH website](http://www.sirahff.com).
+
+
+    Additionally, the file with names ending in **6XEY-RBD-3Man9_SIRAHcg_glycoprot_10us.tar** contains only the protein coordinates, while **6XEY-RBD-3Man9_SIRAHcg_glycoprot_skip10ns.tar** contains one frame every 10ns.
+
+
+    To take a quick look at a the trajectory:
+
+
+    1- Untar the file `6XEY-RBD-3Man9_SIRAHcg_glycoprot_skip10ns.tar`
+
+
+    2- Open the trajectory on VMD using the command line:
+    ```
+    vmd 6XEY-RBD-3Man9_SIRAHcg_glycoprot.prmtop 6XEY-RBD-3Man9_SIRAHcg_10us_skip10ns.ncrst 6XEY-RBD-3Man9_SIRAHcg_10us_skip10ns.nc -e sirah_vmdtk.tcl
+    ```
+
+
+    Note that you can use normal VMD drawing methods as vdw, licorice, etc., and coloring by restype, element, name, etc.
+
+
+creator: Garay Pablo
+organization: Institut Pasteur de Montevideo
+lab: Biomolecular Simulations Laboratory
+proteins:
+    - spike
+    - RBD
+structures:
+    - 6XEY
+trajectory: https://zenodo.org/record/4277989/
+size: 11.2 GB
+length: 10 µs
+ensemble: NPT
+temperature: 300
+pressure: 1
+solvent: water
+salinity: 0.15
+forcefields:
+    - SIRAH 2.2
+references:
+    - "Machado, M. R.; Barrera, E. E.; Klein, F.; Sóñora, M.; Silva, S.; Pantano, S. The SIRAH 2.0 Force Field: Altius, Fortius, Citius. J. Chem. Theory Comput. 2019, acs.jctc.9b00006. https://doi.org/10.1021/acs.jctc.9b00006."
+    - "Machado, M. R.; Pantano, S. Split the Charge Difference in Two! A Rule of Thumb for Adding Proper Amounts of Ions in MD Simulations. J. Chem. Theory Comput. 2020, 16 (3), 1367–1372. https://doi.org/10.1021/acs.jctc.9b00953."
+    - "Machado, M. R.; Pantano, S. SIRAH Tools: Mapping, Backmapping and Visualization of Coarse-Grained Models. Bioinformatics 2016, 32 (10), 1568–1570. https://doi.org/10.1093/bioinformatics/btw020."
+    - "Garay, P. G.; Machado, M. R.; Verli, H.; Pantano, S. SIRAH Late Harvest: Coarse-Grained Models for Protein Glycosylation. bioRxiv 2020. https://doi.org/10.1101/2020.12.18.423446."

--- a/data/simulations/SIRAH-CoV2_initiative-Main_Protease-PDB_6LU7.yml
+++ b/data/simulations/SIRAH-CoV2_initiative-Main_Protease-PDB_6LU7.yml
@@ -1,5 +1,5 @@
 type: md-cg
-title: SIRAH-CoV2 initiative - Main Protease 15 µs trajectory (PDB id 6LU7)
+title: SIRAH-CoV2 initiative - Main Protease
 description: >
     This dataset contains the trajectory of a 15 microseconds-long coarse-grained molecular dynamics simulation of SARS-CoV2 Main protease in its APO form (PDB id: 6LU7, Bioassembly 1). Simulations have been performed using the SIRAH force field running with the Amber18 package at the Uruguayan National Center for Supercomputing (ClusterUY) under the conditions reported in [Machado et al. JCTC 2019](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00006), adding 150 mM NaCl according to [Machado & Pantano JCTC 2020](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00953).
 

--- a/data/structures/6XDC.yml
+++ b/data/structures/6XDC.yml
@@ -1,0 +1,10 @@
+pdbid: 6XDC
+method: ELECTRON MICROSCOPY
+resolution: 2.9
+organisms:
+  - SARS-CoV-2
+proteins:
+  - ORF3a
+targets:
+  - host immune response
+annotation: "Cryo-EM structure of SARS-CoV-2 ORF3a"

--- a/data/structures/6XEY.yml
+++ b/data/structures/6XEY.yml
@@ -1,0 +1,11 @@
+pdbid: 6XEY
+method: ELECTRON MICROSCOPY
+resolution: 3.25
+organisms:
+  - SARS-CoV-2
+proteins:
+  - spike
+  - RBD
+targets:
+  - spike binding
+annotation: "Cryo-EM structure of the SARS-CoV-2 spike glycoprotein bound to Fab 2-4"

--- a/data/structures/6ZSL.yml
+++ b/data/structures/6ZSL.yml
@@ -1,0 +1,10 @@
+pdbid: 6ZSL
+method: X-RAY DIFFRACTION
+resolution: 1.94
+organisms:
+  - SARS-CoV-2
+proteins:
+  - Helicase
+targets:
+  - viral replication
+annotation: "Crystal structure of the SARS-CoV-2 helicase at 1.94 Angstrom resolution"


### PR DESCRIPTION
## Description  
Coarse-grain SIRAH MD for:  
- 6XDC; *Membrane embedded SARS-CoV-2 ORF3a*.  
- 6ZSL; *SARS-CoV-2 helicase*.  
- 6XEY; *RBD triple glycosylated at Asn331, 343, and 481 from PDB structure 6XEY*.  

The corresponding `.yml` files for these entries are added to the data/structures directory. And, some typos in other entries are corrected.

## Status
- [X] YAML file for each piece of data
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


