### PR TITLE
Prevent entries with only subdomain proteins

### DIFF
--- a/data/models/wellawatte_6lxt_CHAINs_ABC_CG.yml
+++ b/data/models/wellawatte_6lxt_CHAINs_ABC_CG.yml
@@ -8,6 +8,7 @@ pdbids:
   - 6lxt
 proteins:
   - S2
+  - spike
 creator: Geemi Wellawatte, White Lab, University of Rochester
 
 lab: Zhiheng Li, Xu Group, University of Rochester (contributor)

--- a/data/models/wellawatte_6vw1_RBD_CG.yml
+++ b/data/models/wellawatte_6vw1_RBD_CG.yml
@@ -7,6 +7,7 @@ pdbids:
   - 6vw1
 proteins:
   - RBD
+  - spike
 creator: Geemi Wellawatte, White Lab, University of Rochester
 
 

--- a/data/models/wellawatte_6w41_CG.yml
+++ b/data/models/wellawatte_6w41_CG.yml
@@ -7,6 +7,7 @@ pdbids:
   - 6w41
 proteins:
   - RBD
+  - spike
 creator: Geemi Wellawatte, White Lab, University of Rochester
 
 lab: Zhiheng Li, Xu Group, University of Rochester (contributor)


### PR DESCRIPTION
## Description
Since subdomains are not handled well yet, anyone providing a valid
subdomain, but not the parent protein, to a list of `proteins` will
not have the entry displayed correctly.

This PR adds a check to the validator to prevent subdomain-only entries
while also fixing a couple entries which were subdomain-only so they
will now correctly appear on the site.


## Status
- [x] YAML file for each piece of data
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


