### PR TITLE
Speed up build times

### DIFF
--- a/themes/minimal/layouts/models/single.html
+++ b/themes/minimal/layouts/models/single.html
@@ -6,6 +6,8 @@
 {{ $protein_map := partial "protein-map" . }}
 {{ $target_map := partial "target-map" . }}
 {{ $model_map := partial "model-map" . }}
+{{ $structure_to_targets := partial "structure-to-targets" . }}
+{{ $protein_to_targets := partial "protein-to-targets" . }}
 {{ $domain_sort := partial "master-domain-index" . }}
 {{ $domain_keys := $domain_sort.keys }}
 {{ $domain_titles := $domain_sort.titles }}
@@ -92,7 +94,7 @@
                     {{ $protein := $localScratch.Get "protein" }}
                     {{ $target := $localScratch.Get "target" }}
                     <!-- Get the Targets by all the PDBs... Using a helper function -->
-                    {{ $known_targets := partial "list-model-targets" (dict "model" . "context" $ ) }}
+                    {{ $known_targets := partial "list-model-targets" (dict "model" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                     {{ if and (in .proteins $protein) (in $known_targets $target) }}
                         {{ $localScratch.Set "has_content" true }}
                     {{ end }}
@@ -103,7 +105,7 @@
                     {{ range sort $.Site.Data.models "rating" "desc" }}
                         {{ $protein := $localScratch.Get "protein" }}
                         {{ $target := $localScratch.Get "target" }}
-                        {{ $known_targets := partial "list-model-targets" (dict "model" . "context" $ ) }}
+                        {{ $known_targets := partial "list-model-targets" (dict "model" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                         {{ if and (in .proteins $protein) (in $known_targets $target) }}
                             {{ partial "model-entry" (dict "model" . "protein" $protein "target" $target  "context" $) }}
                         {{ end }}
@@ -113,7 +115,7 @@
             <!-- Special Case of having no targets -->
             {{ range sort $.Site.Data.models "rating" "desc" }}
                 {{ $protein := $localScratch.Get "protein" }}
-                {{ $known_targets := partial "list-model-targets" (dict "model" . "context" $ ) }}
+                {{ $known_targets := partial "list-model-targets" (dict "model" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                 {{ if and (in .proteins $protein) (not $known_targets) }}
                     {{ $localScratch.Set "has_content" true }}
                 {{ end }}
@@ -123,7 +125,7 @@
                 <!-- Finally Structures -->
                 {{ range sort $.Site.Data.models "rating" "desc" }}
                     {{ $protein := $localScratch.Get "protein" }}
-                    {{ $known_targets := partial "list-model-targets" (dict "model" . "context" $ ) }}
+                    {{ $known_targets := partial "list-model-targets" (dict "model" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                     {{ if and (in .proteins $protein) (not $known_targets) }}
                         {{ partial "model-entry" (dict "model" . "protein" $protein "target" "nil" "context" $) }}
                     {{ end }}
@@ -150,7 +152,7 @@
                         {{ $protein := $localScratch.Get "protein" }}
                         {{ $target := $localScratch.Get "target" }}
                         <!-- Get the Targets by all the PDBs... Using a helper function -->
-                        {{ $known_targets := partial "list-model-targets" (dict "model" . "context" $ ) }}
+                        {{ $known_targets := partial "list-model-targets" (dict "model" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                         {{ if and (in .proteins $protein) (in $known_targets $target) }}
                             {{ $localScratch.Set "has_content" true }}
                         {{ end }}
@@ -161,7 +163,7 @@
                         {{ range sort $.Site.Data.models "rating" "desc" }}
                             {{ $protein := $localScratch.Get "protein" }}
                             {{ $target := $localScratch.Get "target" }}
-                            {{ $known_targets := partial "list-model-targets" (dict "model" . "context" $ ) }}
+                            {{ $known_targets := partial "list-model-targets" (dict "model" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                             {{ if and (in .proteins $protein) (in $known_targets $target) }}
                                 {{ partial "model-entry" (dict "model" .  "protein" $protein "target" $target  "context" $) }}
                             {{ end }}
@@ -171,7 +173,7 @@
                 <!-- Special Case of having no targets -->
                 {{ range sort $.Site.Data.models "rating" "desc" }}
                     {{ $protein := $localScratch.Get "protein" }}
-                    {{ $known_targets := partial "list-model-targets" (dict "model" . "context" $ ) }}
+                    {{ $known_targets := partial "list-model-targets" (dict "model" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                     {{ if and (in .proteins $protein) (not $known_targets) }}
                         {{ $localScratch.Set "has_content" true }}
                     {{ end }}
@@ -181,7 +183,7 @@
                     <!-- Finally Structures -->
                     {{ range sort $.Site.Data.models "rating" "desc" }}
                         {{ $protein := $localScratch.Get "protein" }}
-                        {{ $known_targets := partial "list-model-targets" (dict "model" . "context" $ ) }}
+                        {{ $known_targets := partial "list-model-targets" (dict "model" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                         {{ if and (in .proteins $protein) (not $known_targets) }}
                             {{ partial "model-entry" (dict "model" . "protein" $protein "target" "nil"  "context" $) }}
                         {{ end }}

--- a/themes/minimal/layouts/partials/list-model-targets.html
+++ b/themes/minimal/layouts/partials/list-model-targets.html
@@ -4,31 +4,13 @@
 {{ $localScratch.Set "targets" slice }}
 
 {{ range .model.pdbids }}
-    {{ $localScratch.Set "model_pdb" . }}
-    {{ range $.context.Site.Data.structures }}
-        {{ $localScratch.Set "structure" . }}
-        {{ $model_pdb := ($localScratch.Get "model_pdb" | upper) }}
-        {{ if or (eq (.pdbid | upper) $model_pdb) (eq (.unpublished_pdbid | upper) $model_pdb)}}
-            {{ if ($localScratch.Get "structure").targets }}
-                {{ $targets := partial "ensure-slice" ($localScratch.Get "structure").targets }}
-                {{ $localScratch.Set "targets" (($localScratch.Get "targets") | append $targets )}}
-            {{ end }}
-        {{ end }}
-    {{ end }}
+    {{ $targets := index $.structureMap (. | upper) | default slice }}
+    {{ $localScratch.Set "targets" (($localScratch.Get "targets") | append $targets )}}
 {{ end }}
 
 {{ range .model.proteins }}
-    {{ $localScratch.Set "model_protein" . }}
-    {{ range $.context.Site.Data.proteins }}
-        {{ $localScratch.Set "protein" . }}
-        {{ $model_protein := ($localScratch.Get "model_protein" | upper) }}
-        {{ if eq (.protein | upper) $model_protein }}
-            {{ if ($localScratch.Get "protein").targets }}
-                {{ $targets := partial "ensure-slice" ($localScratch.Get "protein").targets }}
-                {{ $localScratch.Set "targets" (($localScratch.Get "targets") | append $targets )}}
-            {{ end }}
-        {{ end }}
-    {{ end }}
+    {{ $targets := index $.proteinMap (. | upper) | default slice }}
+    {{ $localScratch.Set "targets" (($localScratch.Get "targets") | append $targets )}}
 {{ end }}
 
 {{ return (uniq ($localScratch.Get "targets")) }}

--- a/themes/minimal/layouts/partials/list-simulation-targets.html
+++ b/themes/minimal/layouts/partials/list-simulation-targets.html
@@ -8,24 +8,16 @@
     {{ range $mname, $mcontent := $.context.Site.Data.models }}
         {{ $model_id := $localScratch.Get "model_id"}}
         {{ if eq $mname $model_id }}
-            {{ $targets := partial "list-model-targets" (dict "model" . "context" $.context ) }}
+            {{ $targets := partial "list-model-targets-renew" (dict "model" . "structureMap" $.structureMap "proteinMap" $.proteinMap ) }}
             {{ $localScratch.Set "targets" (($localScratch.Get "targets") | append $targets )}}
         {{ end }}
     {{ end }}
 {{ end }}
 
+
 {{ range .simulation.proteins }}
-    {{ $localScratch.Set "sim_protein" . }}
-    {{ range $.context.Site.Data.proteins }}
-        {{ $localScratch.Set "protein" . }}
-        {{ $sim_protein := ($localScratch.Get "sim_protein" | upper) }}
-        {{ if eq (.protein | upper) $sim_protein }}
-            {{ if ($localScratch.Get "protein").targets }}
-                {{ $targets := partial "ensure-slice" ($localScratch.Get "protein").targets }}
-                {{ $localScratch.Set "targets" (($localScratch.Get "targets") | append $targets )}}
-            {{ end }}
-        {{ end }}
-    {{ end }}
+    {{ $targets := index $.proteinMap (. | upper) | default slice }}
+    {{ $localScratch.Set "targets" (($localScratch.Get "targets") | append $targets )}}
 {{ end }}
 
 {{ return (uniq ($localScratch.Get "targets")) }}

--- a/themes/minimal/layouts/partials/protein-to-targets.html
+++ b/themes/minimal/layouts/partials/protein-to-targets.html
@@ -1,0 +1,20 @@
+<!-- Helper function to map proteins to targets by a lookup -->
+{{ $localScratch := newScratch }}
+
+{{ $localScratch.Set "target-map" dict }}
+
+{{ range $.Site.Data.proteins }}
+    {{ $localScratch.Set "protein" . }}
+    {{ if .targets }}
+        <!-- Set the local set of targets to empty slice -->
+        {{ $localScratch.Set "targets" (partial "ensure-slice" .targets) }}
+        <!-- Get the existing key in the map, if its not there, make a default slice-->
+        {{ $proteinTargets := index ($localScratch.Get "target-map") (.protein | upper ) | default slice }}
+        <!-- Expand the unique slice of targets -->
+        {{ $proteinTargets := $proteinTargets | append ($localScratch.Get "targets") | uniq }}
+        <!-- Reset the key, since we pulled the whole key the first time, we can just set again -->
+        {{ $localScratch.Set "target-map" (merge ($localScratch.Get "target-map") (dict (.protein | upper) $proteinTargets)) }}
+    {{ end }}
+{{ end }}
+
+{{ return ($localScratch.Get "target-map") }}

--- a/themes/minimal/layouts/partials/structure-to-targets.html
+++ b/themes/minimal/layouts/partials/structure-to-targets.html
@@ -1,0 +1,30 @@
+<!-- Helper function to map structures to targets by a lookup -->
+{{ $localScratch := newScratch }}
+
+{{ $localScratch.Set "target-map" dict }}
+
+{{ range $.Site.Data.structures }}
+    {{ $localScratch.Set "structure" . }}
+    {{ if .targets }}
+        <!-- Set the local set of targets to empty slice -->
+        {{ $localScratch.Set "targets" (partial "ensure-slice" .targets) }}
+        {{ if .pdbid }}
+            <!-- Get the existing key in the map, if its not there, make a default slice-->
+            {{ $pdbTargets := index ($localScratch.Get "target-map") (.pdbid | upper ) | default slice }}
+            <!-- Expand the unique slice of targets -->
+            {{ $pdbTargets := $pdbTargets | append ($localScratch.Get "targets") | uniq }}
+            <!-- Reset the key, since we pulled the whole key the first time, we can just set again -->
+            {{ $localScratch.Set "target-map" (merge ($localScratch.Get "target-map") (dict (.pdbid | upper) $pdbTargets)) }}
+        {{ end }}
+        {{ if .unpublished_pdbid }}
+            <!-- Get the existing key in the map, if its not there, make a default slice-->
+            {{ $pdbTargets := index ($localScratch.Get "target-map") .unpublished_pdbid | default slice }}
+            <!-- Expand the unique slice of targets -->
+            {{ $pdbTargets := $pdbTargets | append ($localScratch.Get "targets") | uniq }}
+            <!-- Reset the key, since we pulled the whole key the first time, we can just set again -->
+            {{ $localScratch.Set "target-map" (merge ($localScratch.Get "target-map") (dict (.unpublished_pdbid | upper) $pdbTargets)) }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
+{{ return ($localScratch.Get "target-map") }}

--- a/themes/minimal/layouts/simulations/single.html
+++ b/themes/minimal/layouts/simulations/single.html
@@ -6,6 +6,8 @@
 {{ $target_map := partial "target-map" . }}
 {{ $protein_map := partial "protein-map" . }}
 {{ $sim_map := partial "sim-map" . }}
+{{ $structure_to_targets := partial "structure-to-targets" . }}
+{{ $protein_to_targets := partial "protein-to-targets" . }}
 {{ $domain_sort := partial "master-domain-index" . }}
 {{ $domain_keys := $domain_sort.keys }}
 {{ $domain_titles := $domain_sort.titles }}
@@ -88,7 +90,7 @@
                     {{ $protein := $localScratch.Get "protein" }}
                     {{ $target := $localScratch.Get "target" }}
                     <!-- Get the Targets by all the PDBs... Using a helper function -->
-                    {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "context" $ ) }}
+                    {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                     {{ if and (in .proteins $protein) (in $known_targets $target) }}
                         {{ $localScratch.Set "has_content" true }}
                     {{ end }}
@@ -100,7 +102,7 @@
                     {{ range sort $.Site.Data.simulations "rating" "desc" }}
                         {{ $protein := $localScratch.Get "protein" }}
                         {{ $target := $localScratch.Get "target" }}
-                        {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "context" $ ) }}
+                        {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                         {{ if and (in .proteins $protein) (in $known_targets $target) }}
                             {{ partial "simulation-entry" (dict "simulation" . "protein" $protein "target" $target "context" $) }}
                         {{ end }}
@@ -110,7 +112,7 @@
             <!-- Special Case of having no targets -->
             {{ range sort $.Site.Data.simulations "rating" "desc" }}
                 {{ $protein := $localScratch.Get "protein" }}
-                {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "context" $ ) }}
+                {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                 {{ if and (in .proteins $protein) (not $known_targets) }}
                     {{ $localScratch.Set "has_content" true }}
                 {{ end }}
@@ -120,7 +122,7 @@
                 <!-- Finally Structures -->
                 {{ range sort $.Site.Data.simulations "rating" "desc" }}
                     {{ $protein := $localScratch.Get "protein" }}
-                    {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "context" $ ) }}
+                    {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                     {{ if and (in .proteins $protein) (not $known_targets) }}
                         {{ partial "simulation-entry" (dict "simulation" . "protein" $protein "target" "nil" "context" $) }}
                     {{ end }}
@@ -148,7 +150,7 @@
                     {{ $protein := $localScratch.Get "protein" }}
                     {{ $target := $localScratch.Get "target" }}
                     <!-- Get the Targets by all the PDBs... Using a helper function -->
-                    {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "context" $ ) }}
+                    {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                     {{ if and (in .proteins $protein) (in $known_targets $target) }}
                         {{ $localScratch.Set "has_content" true }}
                     {{ end }}
@@ -160,7 +162,7 @@
                     {{ range sort $.Site.Data.simulations "rating" "desc" }}
                         {{ $protein := $localScratch.Get "protein" }}
                         {{ $target := $localScratch.Get "target" }}
-                        {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "context" $ ) }}
+                        {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                         {{ if and (in .proteins $protein) (in $known_targets $target) }}
                             {{ partial "simulation-entry" (dict "simulation" . "protein" $protein "target" $target "context" $) }}
                         {{ end }}
@@ -170,7 +172,7 @@
             <!-- Special Case of having no targets -->
             {{ range sort $.Site.Data.simulations "rating" "desc" }}
                 {{ $protein := $localScratch.Get "protein" }}
-                {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "context" $ ) }}
+                {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                 {{ if and (in .proteins $protein) (not $known_targets) }}
                     {{ $localScratch.Set "has_content" true }}
                 {{ end }}
@@ -180,7 +182,7 @@
                 <!-- Finally Structures -->
                 {{ range sort $.Site.Data.simulations "rating" "desc" }}
                     {{ $protein := $localScratch.Get "protein" }}
-                    {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "context" $ ) }}
+                    {{ $known_targets := partial "list-simulation-targets" (dict "simulation" . "structureMap" $structure_to_targets "proteinMap" $protein_to_targets ) }}
                     {{ if and (in .proteins $protein) (not $known_targets) }}
                         {{ partial "simulation-entry" (dict "simulation" . "protein" $protein "target" "nil" "context" $) }}
                     {{ end }}


### PR DESCRIPTION
Speed up re-render times by reducing the number of loops through the data.

Old version would loop through the structures and proteins directory
several thousand times over the build, giving it upwards of 55+ seconds
per build. This PR gets builds down to 4-5 seconds each.

## Description
Provide a brief description of the data being added here.


## Status
- [x] YAML file for each piece of data
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


