### PR TITLE
Fixed a typo in title names where links could not populate with overlapping titles

### DIFF
--- a/data/simulations/FAH_SARS-CoV-2_nsp5_dimer.yml
+++ b/data/simulations/FAH_SARS-CoV-2_nsp5_dimer.yml
@@ -1,6 +1,6 @@
 target: nsp5
 type: md
-title: Folding@home simulations of nsp5
+title: Folding@home simulations of nsp5 dimer
 description: >
   All-atom MD simulations of nsp5, simulated using [Folding@Home](https://doi.org/10.1101/2020.06.27.175430).
   The dataset comprises 4 projects, each having a `RUN*/CLONE*/result*` directory structure.

--- a/data/simulations/FAH_SARS-CoV-2_nsp5_monomer.yml
+++ b/data/simulations/FAH_SARS-CoV-2_nsp5_monomer.yml
@@ -1,6 +1,6 @@
 target: nsp5
 type: md
-title: Folding@home simulations of nsp5
+title: Folding@home simulations of nsp5 monomer
 description: >
   All-atom MD simulations of nsp5, simulated using [Folding@Home](https://doi.org/10.1101/2020.06.27.175430).
   The dataset comprises 4 projects, each having a `RUN*/CLONE*/result*` directory structure.


### PR DESCRIPTION
## Description
Two entries shared a title, this has been fixed


## Status
- [x] YAML file for each piece of data
- [x] Ready to go

<!---
### This wont show up in your PR, its just info for you ###

Data is submitted as YAML files into the `/data/{TYPE}/README.md` directory.
Schema for each directory is in each of the `/data/{TYPE}/README.md` files.


A new YAML file should be created for *every* new piece of data.

This structure is subject to change, but all changes will be made by a maintainer and the instructions 
updated accordingly.

-->


